### PR TITLE
feat: intelligente Hintergrund-Reisebegleitung und Verpasst-Hilfe

### DIFF
--- a/PRIVACY-POLICY.md
+++ b/PRIVACY-POLICY.md
@@ -16,6 +16,7 @@ Better Bahn ("Besser Bahn") is a free and open-source application that helps use
 
 - **DB Links:** URLs from bahn.de that you paste into the app to analyze train connections
 - **User preferences:** Your settings such as age, BahnCard type, and Deutschland-Ticket status
+- **Optional background location:** If you explicitly enable the GPS journey companion, the app processes your device position locally during an active watched journey to warn before your stop, estimate possible unreported delays, and suggest alternatives after a possibly missed train or connection. The position is not sent to the developer or stored in a developer-operated service. Android shows a persistent notification while this is active, and the feature can be disabled in Settings at any time.
 
 All this data is processed locally on your device and is never sent to any server operated by the developer.
 

--- a/flutter-app/android/app/src/main/AndroidManifest.xml
+++ b/flutter-app/android/app/src/main/AndroidManifest.xml
@@ -1,18 +1,15 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Add internet permission -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- libre_location ships a full background-tracking manifest. We only use a
-         one-shot foreground fix ("Mein Standort"), so strip everything it merges
-         in beyond ACCESS_FINE/COARSE_LOCATION. Re-enable the specific lines below
-         if/when we add a real background-tracking feature. -->
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" tools:node="remove" />
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" tools:node="remove" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" tools:node="remove" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove" />
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" tools:node="remove" />
+    <!-- GPS journey companion: continuous, visible foreground service while a
+         watched journey is active, including process death and device reboot. -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <!-- "Mein Standort" on the Bahnhofskarte: show the user's position and the
          direction toward their boarding Gleis. Coarse + fine; while-in-use. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -36,9 +33,6 @@
         android:label="Besser Bahn"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
-        <!-- Drop libre_location's background components (we only do one-shot fixes). -->
-        <service android:name="io.rezivure.libre_location.LocationService" tools:node="remove" />
-        <receiver android:name="io.rezivure.libre_location.BootReceiver" tools:node="remove" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/flutter-app/ios/Runner/Info.plist
+++ b/flutter-app/ios/Runner/Info.plist
@@ -8,6 +8,19 @@
 	     direction toward their boarding Gleis. -->
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Zeigt deinen Standort auf der Bahnhofskarte, damit du siehst, wo du bist und in welche Richtung dein Gleis liegt.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Begleitet deine aktivierte Reise im Hintergrund, warnt vor dem Ausstieg und erkennt mögliche ungemeldete Verspätungen.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Erkennt stromsparend, ob du dich während einer aktivierten Reise bewegst.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+		<string>fetch</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>io.rezivure.libre_location.heartbeat</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string>Besser Bahn</string>
 	<key>CFBundleExecutable</key>

--- a/flutter-app/lib/app.dart
+++ b/flutter-app/lib/app.dart
@@ -1,18 +1,64 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'core/constants.dart';
+import 'core/missed_connection.dart';
+import 'providers/background_trip_provider.dart';
+import 'providers/journey_search_provider.dart';
 import 'providers/live_trip_provider.dart';
 import 'providers/reminder_provider.dart';
 import 'providers/travel_stats_provider.dart';
 import 'router/app_router.dart';
+import 'services/notification_service.dart';
 import 'theme/app_theme.dart';
-import 'core/constants.dart';
 
-class BessereBahnApp extends ConsumerWidget {
+class BessereBahnApp extends ConsumerStatefulWidget {
   const BessereBahnApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<BessereBahnApp> createState() => _BessereBahnAppState();
+}
+
+class _BessereBahnAppState extends ConsumerState<BessereBahnApp> {
+  StreamSubscription<MissedConnectionRescue>? _missedSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _missedSubscription = NotificationService.missedRescues.listen((rescue) {
+      unawaited(_openMissedAlternatives(rescue, consumePersisted: true));
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final rescue = await NotificationService.takePendingMissedRescue();
+      if (rescue != null && mounted) await _openMissedAlternatives(rescue);
+    });
+  }
+
+  @override
+  void dispose() {
+    _missedSubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _openMissedAlternatives(
+    MissedConnectionRescue rescue, {
+    bool consumePersisted = false,
+  }) async {
+    if (consumePersisted) await NotificationService.takePendingMissedRescue();
+    if (!mounted) return;
+    final search = ref.read(journeySearchProvider.notifier);
+    search.setFrom(rescue.from);
+    search.setTo(rescue.to);
+    search.setDateTime(DateTime.now().add(const Duration(minutes: 1)));
+    search.setIsArrival(false);
+    ref.read(appRouterProvider).go('/search');
+    await search.search();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // Keep the trip-reminder scheduler alive: it watches saved trips + settings
     // and (re)schedules offline OS reminders whenever they change.
     ref.watch(reminderSchedulerProvider);
@@ -20,6 +66,9 @@ class BessereBahnApp extends ConsumerWidget {
     // trip is active, it polls live data and fires delay/platform/transfer
     // alerts.
     ref.watch(liveTripTrackerProvider);
+    // Keep the GPS companion aligned with the active watched journey. Its
+    // native foreground service continues independently when this UI closes.
+    ref.watch(backgroundTripControllerProvider);
     // Keep the lifetime travel-stats accumulator alive: it watches saved trips
     // and folds each completed one into the on-device km/punctuality totals.
     ref.watch(travelStatsProvider);

--- a/flutter-app/lib/core/exit_alarm_intelligence.dart
+++ b/flutter-app/lib/core/exit_alarm_intelligence.dart
@@ -1,0 +1,257 @@
+import 'dart:math' as math;
+
+/// One scheduled point along a train leg. The points normally are stations;
+/// interpolating between them is deliberately conservative but good enough to
+/// tell whether the rider is materially behind the timetable.
+class TimedRoutePoint {
+  final double latitude;
+  final double longitude;
+  final DateTime scheduledAt;
+  final int reportedDelaySeconds;
+
+  const TimedRoutePoint({
+    required this.latitude,
+    required this.longitude,
+    required this.scheduledAt,
+    this.reportedDelaySeconds = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'lat': latitude,
+    'lon': longitude,
+    'at': scheduledAt.toIso8601String(),
+    'delay': reportedDelaySeconds,
+  };
+
+  factory TimedRoutePoint.fromJson(Map<String, dynamic> json) =>
+      TimedRoutePoint(
+        latitude: (json['lat'] as num).toDouble(),
+        longitude: (json['lon'] as num).toDouble(),
+        scheduledAt: DateTime.parse(json['at'] as String),
+        reportedDelaySeconds: (json['delay'] as num?)?.toInt() ?? 0,
+      );
+}
+
+class TrackedJourneyLeg {
+  final String id;
+  final String lineName;
+  final String destinationName;
+  final List<TimedRoutePoint> route;
+
+  const TrackedJourneyLeg({
+    required this.id,
+    required this.lineName,
+    required this.destinationName,
+    required this.route,
+  });
+
+  DateTime get departure => route.first.scheduledAt;
+  DateTime get arrival => route.last.scheduledAt;
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'line': lineName,
+    'destination': destinationName,
+    'route': route.map((p) => p.toJson()).toList(),
+  };
+
+  factory TrackedJourneyLeg.fromJson(Map<String, dynamic> json) =>
+      TrackedJourneyLeg(
+        id: json['id'] as String,
+        lineName: json['line'] as String? ?? 'Zug',
+        destinationName: json['destination'] as String,
+        route: (json['route'] as List<dynamic>)
+            .whereType<Map<String, dynamic>>()
+            .map(TimedRoutePoint.fromJson)
+            .toList(growable: false),
+      );
+}
+
+class JourneyPositionSample {
+  final double latitude;
+  final double longitude;
+  final double accuracy;
+  final double speed;
+  final DateTime timestamp;
+
+  const JourneyPositionSample({
+    required this.latitude,
+    required this.longitude,
+    required this.accuracy,
+    required this.speed,
+    required this.timestamp,
+  });
+}
+
+class JourneyPositionInference {
+  final double progress;
+  final double distanceToRouteMetres;
+  final double distanceToDestinationMetres;
+  final int inferredDelayMinutes;
+  final int reportedDelayMinutes;
+  final bool shouldNotifyExit;
+
+  const JourneyPositionInference({
+    required this.progress,
+    required this.distanceToRouteMetres,
+    required this.distanceToDestinationMetres,
+    required this.inferredDelayMinutes,
+    required this.reportedDelayMinutes,
+    required this.shouldNotifyExit,
+  });
+
+  /// A positional delay is only interesting when it is both meaningful and
+  /// clearly worse than the delay DB already reports.
+  bool get suggestsUnreportedDelay =>
+      inferredDelayMinutes >= 5 &&
+      inferredDelayMinutes >= reportedDelayMinutes + 5;
+}
+
+/// Timetable + GPS inference shared by the foreground stream and Android's
+/// headless callback. It has no Flutter dependencies so its edge cases can be
+/// unit-tested without a device.
+class ExitAlarmIntelligence {
+  const ExitAlarmIntelligence();
+
+  JourneyPositionInference? evaluate(
+    TrackedJourneyLeg leg,
+    JourneyPositionSample sample,
+  ) {
+    if (leg.route.length < 2 || sample.accuracy > 250) return null;
+    if (sample.timestamp.isBefore(
+      leg.departure.subtract(const Duration(minutes: 2)),
+    )) {
+      return null;
+    }
+    // Keep tracking a badly delayed train beyond its scheduled arrival, but
+    // don't let yesterday's journey claim today's position.
+    if (sample.timestamp.isAfter(leg.arrival.add(const Duration(hours: 4)))) {
+      return null;
+    }
+
+    _Projection? nearest;
+    for (var i = 0; i < leg.route.length - 1; i++) {
+      final candidate = _project(sample, leg.route[i], leg.route[i + 1], i);
+      if (nearest == null ||
+          candidate.distanceMetres < nearest.distanceMetres) {
+        nearest = candidate;
+      }
+    }
+    if (nearest == null) return null;
+
+    final from = leg.route[nearest.segment];
+    final to = leg.route[nearest.segment + 1];
+    final segmentMetres = _distance(
+      from.latitude,
+      from.longitude,
+      to.latitude,
+      to.longitude,
+    );
+    // A chord between two distant stations does not follow every rail curve.
+    // Widen only in proportion to that chord and cap the tolerance; this keeps
+    // long-distance trains detectable without accepting arbitrary locations.
+    final routeTolerance = math.min(
+      20000.0,
+      math.max(2000.0, segmentMetres * .12),
+    );
+    if (nearest.distanceMetres > routeTolerance) return null;
+
+    final segmentSeconds = to.scheduledAt
+        .difference(from.scheduledAt)
+        .inSeconds;
+    if (segmentSeconds <= 0) return null;
+    final expectedAt = from.scheduledAt.add(
+      Duration(
+        milliseconds: (segmentSeconds * 1000 * nearest.fraction).round(),
+      ),
+    );
+    final inferredDelay = sample.timestamp.difference(expectedAt).inMinutes;
+    final reportedDelay =
+        (from.reportedDelaySeconds +
+            ((to.reportedDelaySeconds - from.reportedDelaySeconds) *
+                    nearest.fraction)
+                .round()) ~/
+        60;
+
+    final completedSegments = nearest.segment + nearest.fraction;
+    final progress = completedSegments / (leg.route.length - 1);
+    final destination = leg.route.last;
+    final destinationMetres = _distance(
+      sample.latitude,
+      sample.longitude,
+      destination.latitude,
+      destination.longitude,
+    );
+    // At railway speed a two-minute look-ahead is useful; cap it so the alarm
+    // never fires many kilometres before the stop. Accuracy expands the radius
+    // slightly instead of allowing a noisy fix to miss the stop altogether.
+    final exitRadius = math.min(
+      2500.0,
+      math.max(1500.0, sample.speed * 120) + sample.accuracy,
+    );
+
+    return JourneyPositionInference(
+      progress: progress.clamp(0, 1),
+      distanceToRouteMetres: nearest.distanceMetres,
+      distanceToDestinationMetres: destinationMetres,
+      inferredDelayMinutes: inferredDelay,
+      reportedDelayMinutes: reportedDelay,
+      // The temporal guard above plus some actual route progress prevents a
+      // rider waiting at the destination before departure from tripping it.
+      shouldNotifyExit: progress >= .08 && destinationMetres <= exitRadius,
+    );
+  }
+
+  _Projection _project(
+    JourneyPositionSample p,
+    TimedRoutePoint a,
+    TimedRoutePoint b,
+    int segment,
+  ) {
+    const earth = 6371000.0;
+    final refLat = _radians((a.latitude + b.latitude + p.latitude) / 3);
+    double x(double lon) => _radians(lon) * math.cos(refLat) * earth;
+    double y(double lat) => _radians(lat) * earth;
+    final ax = x(a.longitude), ay = y(a.latitude);
+    final bx = x(b.longitude), by = y(b.latitude);
+    final px = x(p.longitude), py = y(p.latitude);
+    final dx = bx - ax, dy = by - ay;
+    final lengthSquared = dx * dx + dy * dy;
+    final fraction = lengthSquared == 0
+        ? 0.0
+        : (((px - ax) * dx + (py - ay) * dy) / lengthSquared).clamp(0.0, 1.0);
+    final qx = ax + dx * fraction, qy = ay + dy * fraction;
+    return _Projection(
+      segment: segment,
+      fraction: fraction,
+      distanceMetres: math.sqrt((px - qx) * (px - qx) + (py - qy) * (py - qy)),
+    );
+  }
+
+  double _distance(double lat1, double lon1, double lat2, double lon2) {
+    const earth = 6371000.0;
+    final dLat = _radians(lat2 - lat1);
+    final dLon = _radians(lon2 - lon1);
+    final a =
+        math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(_radians(lat1)) *
+            math.cos(_radians(lat2)) *
+            math.sin(dLon / 2) *
+            math.sin(dLon / 2);
+    return earth * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  }
+
+  double _radians(double degrees) => degrees * math.pi / 180;
+}
+
+class _Projection {
+  final int segment;
+  final double fraction;
+  final double distanceMetres;
+
+  const _Projection({
+    required this.segment,
+    required this.fraction,
+    required this.distanceMetres,
+  });
+}

--- a/flutter-app/lib/core/missed_connection.dart
+++ b/flutter-app/lib/core/missed_connection.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import '../models/journey.dart';
+import '../models/station.dart';
+
+/// Everything needed to restart the journey from the missed boarding point.
+/// It is small enough to travel as a notification payload and contains no
+/// account or ticket data.
+class MissedConnectionRescue {
+  final Station from;
+  final Station to;
+  final DateTime scheduledDeparture;
+  final int legIndex;
+  final bool isConnection;
+
+  const MissedConnectionRescue({
+    required this.from,
+    required this.to,
+    required this.scheduledDeparture,
+    required this.legIndex,
+    required this.isConnection,
+  });
+
+  String get label => isConnection ? 'Anschluss verpasst' : 'Zug verpasst';
+
+  Map<String, dynamic> toJson() => {
+    'from': from.toJson(),
+    'to': to.toJson(),
+    'departure': scheduledDeparture.toIso8601String(),
+    'legIndex': legIndex,
+    'connection': isConnection,
+  };
+
+  String encode() => jsonEncode(toJson());
+
+  factory MissedConnectionRescue.fromJson(Map<String, dynamic> json) =>
+      MissedConnectionRescue(
+        from: Station.fromJson(json['from'] as Map<String, dynamic>? ?? {}),
+        to: Station.fromJson(json['to'] as Map<String, dynamic>? ?? {}),
+        scheduledDeparture: DateTime.parse(json['departure'] as String),
+        legIndex: (json['legIndex'] as num?)?.toInt() ?? 0,
+        isConnection: json['connection'] as bool? ?? false,
+      );
+
+  factory MissedConnectionRescue.decode(String raw) =>
+      MissedConnectionRescue.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+
+  /// The train/connection that can plausibly be missed right now. Starts
+  /// shortly before departure so a rider who already knows they cannot make it
+  /// can reroute without waiting for the timetable to tick past zero.
+  static MissedConnectionRescue? forJourney(Journey journey, {DateTime? now}) {
+    final current = now ?? DateTime.now();
+    final destination = journey.destination;
+    if (destination == null || destination.vendoLocationId.isEmpty) return null;
+
+    final candidates = <MissedConnectionRescue>[];
+    var transitIndex = 0;
+    for (final leg in journey.legs.where((l) => !l.isWalking)) {
+      final departure = leg.departure ?? leg.plannedDeparture;
+      final index = transitIndex++;
+      if (departure == null || leg.origin.vendoLocationId.isEmpty) continue;
+      if (current.isBefore(departure.subtract(const Duration(minutes: 30))) ||
+          current.isAfter(departure.add(const Duration(minutes: 90)))) {
+        continue;
+      }
+      candidates.add(
+        MissedConnectionRescue(
+          from: leg.origin,
+          to: destination,
+          scheduledDeparture: departure,
+          legIndex: index,
+          isConnection: index > 0,
+        ),
+      );
+    }
+    if (candidates.isEmpty) return null;
+
+    // Prefer the most recently due train. Up to ten minutes before departure,
+    // that upcoming train is already the actionable one.
+    candidates.sort((a, b) {
+      final aDue = !a.scheduledDeparture.isAfter(
+        current.add(const Duration(minutes: 10)),
+      );
+      final bDue = !b.scheduledDeparture.isAfter(
+        current.add(const Duration(minutes: 10)),
+      );
+      if (aDue != bDue) return aDue ? -1 : 1;
+      return aDue
+          ? b.scheduledDeparture.compareTo(a.scheduledDeparture)
+          : a.scheduledDeparture.compareTo(b.scheduledDeparture);
+    });
+    return candidates.first;
+  }
+}

--- a/flutter-app/lib/main.dart
+++ b/flutter-app/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'app.dart';
 import 'core/app_log.dart';
 import 'core/tile_cache.dart';
+import 'services/background_trip_tracking.dart';
 import 'services/notification_service.dart';
 
 Future<void> main() async {
@@ -22,6 +23,9 @@ Future<void> main() async {
   TileCache.warmStyle();
   // Best-effort: local notifications (Split-Ticket-Ergebnis). Non-fatal.
   await NotificationService.init();
+  // Persist the Android headless callback before a journey starts. Once the
+  // GPS companion is enabled, native updates can reach Dart without the UI.
+  await BackgroundTripTracking.registerHeadlessCallback();
   runApp(
     const ProviderScope(
       child: BessereBahnApp(),

--- a/flutter-app/lib/providers/background_trip_provider.dart
+++ b/flutter-app/lib/providers/background_trip_provider.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:libre_location/libre_location.dart';
+
+import '../core/app_log.dart';
+import '../models/library_models.dart';
+import '../services/background_trip_tracking.dart';
+import 'library_provider.dart';
+import 'live_trip_provider.dart';
+import 'settings_provider.dart';
+
+/// Keeps the native location service aligned with the one watched journey.
+/// The service itself survives process death; this controller only refreshes
+/// its persisted timetable whenever app/live data changes.
+class BackgroundTripController extends Notifier<bool> {
+  StreamSubscription<Position>? _locations;
+  bool _libraryLoaded = false;
+  bool _settingsLoaded = false;
+  Future<void> _syncQueue = Future<void>.value();
+
+  @override
+  bool build() {
+    ref.listen(libraryProvider, (previous, next) {
+      _libraryLoaded = true;
+      _queueSync();
+    });
+    ref.listen(settingsProvider, (previous, next) {
+      _settingsLoaded = true;
+      _queueSync();
+    });
+    ref.listen(liveTripTrackerProvider, (previous, next) => _queueSync());
+    ref.onDispose(() => _locations?.cancel());
+    return false;
+  }
+
+  void _queueSync() {
+    _syncQueue = _syncQueue.then((_) => _sync()).catchError((Object e) {
+      AppLog.log('background tracking sync failed ($e)', tag: 'live');
+    });
+  }
+
+  Future<void> _sync() async {
+    // Both providers hydrate asynchronously from SharedPreferences. Waiting
+    // for both prevents their temporary default states from stopping a valid
+    // service every time the app launches.
+    if (!_libraryLoaded || !_settingsLoaded) return;
+    final settings = ref.read(settingsProvider);
+    final active = settings.exitAlarmEnabled
+        ? _pickActive(ref.read(libraryProvider).journeys)
+        : null;
+
+    if (active == null) {
+      await BackgroundTripTracking.clearPlan();
+      try {
+        if (await LibreLocation.isTracking) await LibreLocation.stop();
+      } catch (e) {
+        AppLog.log('background tracking stop failed ($e)', tag: 'live');
+      }
+      state = false;
+      return;
+    }
+
+    final live = ref.read(liveTripTrackerProvider);
+    final plan = BackgroundJourneyPlan.fromJourney(
+      active,
+      ringAlarm: settings.arrivalAlarmSound,
+      liveTrips: live.activeKey == active.key ? live.trips : const {},
+    );
+    if (plan.legs.isEmpty) return;
+    await BackgroundTripTracking.writePlan(plan);
+
+    try {
+      final permission = await LibreLocation.checkPermission();
+      if (permission != LocationPermission.always) {
+        state = false;
+        return;
+      }
+      _locations ??= LibreLocation.onLocation.listen(
+        BackgroundTripTracking.processPosition,
+        onError: (Object e) =>
+            AppLog.log('background location stream failed ($e)', tag: 'live'),
+      );
+      if (!await LibreLocation.isTracking) {
+        await LibreLocation.start(
+          preset: TrackingPreset.balanced,
+          config: const LocationConfig(
+            notification: NotificationConfig(
+              title: 'Live-Reisebegleitung aktiv',
+              text: 'Ausstieg und Reiseverlauf werden im Hintergrund erkannt.',
+            ),
+            stopOnTerminate: false,
+            startOnBoot: true,
+            enableHeadless: true,
+          ),
+        );
+      }
+      state = true;
+    } catch (e) {
+      AppLog.log('background tracking start failed ($e)', tag: 'live');
+      state = false;
+    }
+  }
+
+  SavedJourney? _pickActive(List<SavedJourney> journeys) {
+    final now = DateTime.now();
+    final candidates = journeys.where((saved) {
+      if (!saved.watched) return false;
+      final departure =
+          saved.journey.plannedDeparture ?? saved.journey.departure;
+      final arrival = saved.journey.plannedArrival ?? saved.journey.arrival;
+      if (departure == null || arrival == null) return false;
+      return now.isAfter(departure.subtract(const Duration(hours: 1))) &&
+          now.isBefore(arrival.add(const Duration(hours: 4)));
+    }).toList();
+    if (candidates.isEmpty) return null;
+
+    // Prefer a trip that should still be running. If all are nominally over,
+    // the latest departure is the plausible badly delayed one.
+    candidates.sort((a, b) {
+      final aArrival = a.journey.plannedArrival ?? a.journey.arrival!;
+      final bArrival = b.journey.plannedArrival ?? b.journey.arrival!;
+      final aRunning = now.isBefore(aArrival.add(const Duration(minutes: 30)));
+      final bRunning = now.isBefore(bArrival.add(const Duration(minutes: 30)));
+      if (aRunning != bRunning) return aRunning ? -1 : 1;
+      final aDeparture = a.journey.plannedDeparture ?? a.journey.departure!;
+      final bDeparture = b.journey.plannedDeparture ?? b.journey.departure!;
+      return bDeparture.compareTo(aDeparture);
+    });
+    return candidates.first;
+  }
+}
+
+final backgroundTripControllerProvider =
+    NotifierProvider<BackgroundTripController, bool>(
+      BackgroundTripController.new,
+    );

--- a/flutter-app/lib/providers/live_trip_provider.dart
+++ b/flutter-app/lib/providers/live_trip_provider.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:latlong2/latlong.dart';
 
 import '../core/app_log.dart';
 import '../core/extensions.dart';
@@ -40,8 +39,9 @@ class LiveTripState {
 /// It deliberately polls only the active trip's one or two relevant legs, and
 /// only while foreground, so each device touches DB exactly like the official
 /// app's own live view — distributed across all users, no server in the loop
-/// (see [TripReminderScheduler] for why that matters at scale). Closed-app live
-/// alerts would need a foreground service / server push and are out of scope.
+/// (see [TripReminderScheduler] for why that matters at scale). GPS intelligence
+/// is handled separately by the persistent background companion and needs no
+/// server polling while the app is closed.
 class LiveTripTracker extends Notifier<LiveTripState>
     with WidgetsBindingObserver {
   Timer? _timer;
@@ -201,11 +201,6 @@ class LiveTripTracker extends Notifier<LiveTripState>
       }
     }
 
-    // GPS "Ausstiegsalarm": once on board and closing in on the alighting stop,
-    // ring the loud alarm the moment we physically enter its radius — works
-    // even when the timetable is wrong.
-    if (boarded) await _checkExitGeofence(leg);
-
     // Transfer risk: is there still time to catch the next train?
     final next = idx + 1 < transit.length ? transit[idx + 1] : null;
     if (next != null && next.tripId != null) {
@@ -283,41 +278,6 @@ class LiveTripTracker extends Notifier<LiveTripState>
       body = 'Nur $gap Min in $station$why · ab ${dep.hhmm}, beeil dich.';
     }
     _alertOnce('transfer:$tripId', '$gap', title: title, body: body);
-  }
-
-  /// Radius around the alighting stop that trips the GPS exit alarm.
-  static const double _exitRadiusMetres = 1500;
-
-  /// GPS exit alarm. Only runs when the user opted in, the alighting stop has
-  /// coordinates, and arrival is within ~20 min (so we don't burn GPS the whole
-  /// trip). Fires the loud alarm once when the device is inside the radius.
-  Future<void> _checkExitGeofence(JourneyLeg leg) async {
-    if (!ref.read(settingsProvider).exitAlarmEnabled) return;
-    final dest = leg.destination;
-    if (!dest.hasLocation) return;
-    final arr = leg.arrival ?? leg.plannedArrival;
-    if (arr != null && arr.difference(DateTime.now()) > const Duration(minutes: 20)) {
-      return;
-    }
-    final key = 'exit:${dest.id}';
-    if (_lastAlert[key] != null) return; // already rung for this stop
-    try {
-      final fix = await ref.read(locationServiceProvider).currentFix();
-      final metres = const Distance().as(
-        LengthUnit.Meter,
-        fix.latLng,
-        LatLng(dest.latitude!, dest.longitude!),
-      );
-      if (metres <= _exitRadiusMetres) {
-        _lastAlert[key] = '1';
-        NotificationService.showExitAlarm(
-          id: key.hashCode,
-          title: 'Gleich aussteigen: ${dest.name}',
-          body: 'Du bist fast da — ${dest.name}. Sachen schnappen!',
-        );
-        AppLog.log('exit alarm fired near ${dest.name}', tag: 'live');
-      }
-    } catch (_) {/* no fix / permission denied — stay quiet */}
   }
 
   /// Fire an alert for [key] only when [value] differs from what we last sent

--- a/flutter-app/lib/providers/settings_provider.dart
+++ b/flutter-app/lib/providers/settings_provider.dart
@@ -45,9 +45,10 @@ class AppSettings {
   /// since it's deliberately hard to sleep through.
   final bool arrivalAlarmSound;
 
-  /// GPS "Ausstiegsalarm": while on board and the app is open, ring the loud
-  /// alarm the moment the device enters the destination's radius — delay-proof,
-  /// unlike the timetable-based arrival ping. Off by default (uses location).
+  /// GPS journey companion: tracks a watched journey in the background, warns
+  /// near the destination and can infer a likely not-yet-reported delay from
+  /// timetable + position. [arrivalAlarmSound] separately decides whether the
+  /// destination warning becomes a real ringing alarm.
   final bool exitAlarmEnabled;
 
   /// How fast this rider changes trains. Scales how tight a transfer is judged

--- a/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
+++ b/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../core/app_log.dart';
 import '../../core/extensions.dart';
+import '../../core/missed_connection.dart';
 import '../../core/share_text.dart';
 import '../../models/coach_sequence.dart';
 import '../../models/journey.dart';
@@ -201,6 +202,7 @@ class _ConnectionDetailScreenState
   Widget build(BuildContext context) {
     final legs = journey.legs;
     final ticketRef = widget.ticketRef;
+    final missed = MissedConnectionRescue.forJourney(journey);
     return Scaffold(
       appBar: AppBar(
         // Full route is cut off on a phone here → moved into the summary block.
@@ -382,6 +384,12 @@ class _ConnectionDetailScreenState
           // folded into the summary block above (TripProgressInline).
           FahrgastrechteCard(journey: journey),
           DepartureCard(journey: journey),
+          if (missed != null)
+            _MissedConnectionCard(
+              rescue: missed,
+              onPressed: () =>
+                  _showMissedAlternatives(context, ref, missed),
+            ),
           for (var i = 0; i < legs.length; i++) ...[
             if (i > 0) _transfer(context, ref, legs[i - 1], legs[i]),
             if (legs[i].isWalking)
@@ -621,6 +629,23 @@ class _ConnectionDetailScreenState
     n.setFrom(from);
     n.setTo(to);
     n.setDateTime(journey.plannedDeparture ?? journey.departure);
+    n.setIsArrival(false);
+    context.go('/search');
+    n.search();
+  }
+
+  /// Reroute from the specific boarding stop that was missed, not from the
+  /// journey's original origin. The same action therefore also works halfway
+  /// through a journey after a missed connection.
+  void _showMissedAlternatives(
+    BuildContext context,
+    WidgetRef ref,
+    MissedConnectionRescue rescue,
+  ) {
+    final n = ref.read(journeySearchProvider.notifier);
+    n.setFrom(rescue.from);
+    n.setTo(rescue.to);
+    n.setDateTime(DateTime.now().add(const Duration(minutes: 1)));
     n.setIsArrival(false);
     context.go('/search');
     n.search();
@@ -1653,6 +1678,60 @@ class _TripDetailsUnavailable extends StatelessWidget {
 /// Top-of-screen banner: the connection as planned can't be travelled because a
 /// train fully cancels (red) or drops a stop (amber). Points the rider at the
 /// per-Fahrtblock alternative-departure switcher further down.
+class _MissedConnectionCard extends StatelessWidget {
+  final MissedConnectionRescue rescue;
+  final VoidCallback onPressed;
+
+  const _MissedConnectionCard({
+    required this.rescue,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      color: colors.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(Icons.directions_run, color: colors.onSecondaryContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    rescue.isConnection
+                        ? 'Anschluss nicht geschafft?'
+                        : 'Zug nicht geschafft?',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: colors.onSecondaryContainer,
+                        ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Neue Verbindungen ab ${rescue.from.name} suchen.',
+                    style: TextStyle(color: colors.onSecondaryContainer),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed: onPressed,
+              child: const Text('Verpasst'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _JourneyCancelBanner extends StatelessWidget {
   final bool partial;
   const _JourneyCancelBanner({required this.partial});

--- a/flutter-app/lib/screens/settings/settings_screen.dart
+++ b/flutter-app/lib/screens/settings/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../models/split_ticket.dart';
 import '../../models/transfer_profile.dart';
 import '../../models/traewelling_models.dart';
 import '../../providers/offline_package_provider.dart';
+import '../../providers/service_providers.dart';
 import '../../providers/settings_provider.dart';
 import '../../providers/traewelling_provider.dart';
 import '../../services/notification_service.dart';
@@ -123,13 +124,15 @@ class SettingsScreen extends ConsumerWidget {
                     if (v) NotificationService.requestPermissions();
                   },
                 ),
-                if (settings.arrivalAlertEnabled) ...[
+                if (settings.arrivalAlertEnabled ||
+                    settings.exitAlarmEnabled) ...[
                   const Divider(height: 1),
                   SwitchListTile(
                     secondary: const Icon(Icons.alarm),
-                    title: const Text('Klingeln statt nur vibrieren'),
+                    title: const Text('Laut klingeln'),
                     subtitle: const Text(
-                        '5 Min vorher laut klingeln, bis du es stoppst.'),
+                        'Ankunfts- und GPS-Hinweis als echten Wecker klingeln '
+                        'lassen, bis du ihn stoppst.'),
                     value: settings.arrivalAlarmSound,
                     onChanged: (v) {
                       notifier.setArrivalAlarmSound(v);
@@ -142,12 +145,26 @@ class SettingsScreen extends ConsumerWidget {
                   secondary: const Icon(Icons.my_location),
                   title: const Text('GPS-Ausstiegsalarm'),
                   subtitle: const Text(
-                      'Klingelt per Standort, sobald du am Ziel ankommst — '
-                      'verspätungssicher (App muss offen sein).'),
+                      'Läuft im Hintergrund: warnt am Ziel und erkennt per '
+                      'Fahrplan + Position mögliche ungemeldete Verspätung.'),
                   value: settings.exitAlarmEnabled,
-                  onChanged: (v) {
-                    notifier.setExitAlarmEnabled(v);
-                    if (v) NotificationService.requestPermissions();
+                  onChanged: (v) async {
+                    if (!v) {
+                      notifier.setExitAlarmEnabled(false);
+                      return;
+                    }
+                    try {
+                      await ref
+                          .read(locationServiceProvider)
+                          .ensureBackgroundPermission();
+                      notifier.setExitAlarmEnabled(true);
+                      await NotificationService.requestPermissions();
+                    } catch (e) {
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(e.toString())),
+                      );
+                    }
                   },
                 ),
                 const Divider(height: 1),

--- a/flutter-app/lib/services/background_trip_tracking.dart
+++ b/flutter-app/lib/services/background_trip_tracking.dart
@@ -1,0 +1,527 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui' show DartPluginRegistrant;
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:libre_location/libre_location.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../core/app_log.dart';
+import '../core/exit_alarm_intelligence.dart';
+import '../core/missed_connection.dart';
+import '../models/journey.dart';
+import '../models/library_models.dart';
+import '../models/station.dart';
+import '../models/trip.dart';
+import 'notification_service.dart';
+
+const _planKey = 'background_trip_plan_v1';
+const _stateKey = 'background_trip_state_v1';
+const _headlessChannel = MethodChannel('libre_location/headless');
+
+/// Entry point started by libre_location after Android has removed the UI
+/// process. The package persists this callback handle, while this dispatcher
+/// installs the channel that receives each native location update.
+@pragma('vm:entry-point')
+void exitAlarmHeadlessDispatcher() {
+  WidgetsFlutterBinding.ensureInitialized();
+  DartPluginRegistrant.ensureInitialized();
+  _headlessChannel.setMethodCallHandler((call) async {
+    if (call.method == 'onLocationUpdate' && call.arguments is Map) {
+      await BackgroundTripTracking.processPositionMap(
+        Map<String, dynamic>.from(call.arguments as Map),
+      );
+    }
+  });
+  unawaited(_headlessChannel.invokeMethod<void>('initialized'));
+}
+
+/// libre_location requires a second top-level callback handle. Current Android
+/// versions deliver through the dispatcher channel above; keeping this fully
+/// functional also covers platforms/package versions that call it directly.
+@pragma('vm:entry-point')
+void exitAlarmHeadlessLocation(Map<String, dynamic> data) {
+  unawaited(BackgroundTripTracking.processPositionMap(data));
+}
+
+class BackgroundJourneyPlan {
+  final String journeyKey;
+  final bool ringAlarm;
+  final List<TrackedJourneyLeg> legs;
+  final Map<String, MissedConnectionRescue> rescues;
+
+  const BackgroundJourneyPlan({
+    required this.journeyKey,
+    required this.ringAlarm,
+    required this.legs,
+    this.rescues = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+    'journeyKey': journeyKey,
+    'ringAlarm': ringAlarm,
+    'legs': legs.map((l) => l.toJson()).toList(),
+    'rescues': rescues.map((key, value) => MapEntry(key, value.toJson())),
+  };
+
+  factory BackgroundJourneyPlan.fromJson(Map<String, dynamic> json) =>
+      BackgroundJourneyPlan(
+        journeyKey: json['journeyKey'] as String,
+        ringAlarm: json['ringAlarm'] as bool? ?? false,
+        legs: (json['legs'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(TrackedJourneyLeg.fromJson)
+            .where((l) => l.route.length >= 2)
+            .toList(growable: false),
+        rescues:
+            (json['rescues'] as Map?)?.map(
+              (key, value) => MapEntry(
+                key.toString(),
+                MissedConnectionRescue.fromJson(
+                  Map<String, dynamic>.from(value as Map),
+                ),
+              ),
+            ) ??
+            const {},
+      );
+
+  factory BackgroundJourneyPlan.fromJourney(
+    SavedJourney saved, {
+    required bool ringAlarm,
+    Map<String, Trip> liveTrips = const {},
+  }) {
+    final legs = <TrackedJourneyLeg>[];
+    final rescues = <String, MissedConnectionRescue>{};
+    final finalDestination = saved.journey.destination;
+    var index = 0;
+    for (final leg in saved.journey.legs.where((l) => !l.isWalking)) {
+      final legIndex = index++;
+      final route = _timedRoute(leg, liveTrips[leg.tripId]);
+      if (route.length < 2) continue;
+      final id = '${leg.tripId ?? saved.key}:$legIndex';
+      legs.add(
+        TrackedJourneyLeg(
+          id: id,
+          lineName: leg.line?.displayName ?? 'Zug',
+          destinationName: leg.destination.name,
+          route: route,
+        ),
+      );
+      if (finalDestination != null) {
+        rescues[id] = MissedConnectionRescue(
+          from: leg.origin,
+          to: finalDestination,
+          scheduledDeparture: route.first.scheduledAt,
+          legIndex: legIndex,
+          isConnection: legIndex > 0,
+        );
+      }
+    }
+    return BackgroundJourneyPlan(
+      journeyKey: saved.key,
+      ringAlarm: ringAlarm,
+      legs: legs,
+      rescues: rescues,
+    );
+  }
+
+  static List<TimedRoutePoint> _timedRoute(JourneyLeg leg, Trip? liveTrip) {
+    final points = <TimedRoutePoint>[];
+
+    if (liveTrip != null) {
+      final origin = liveTrip.stopovers.indexWhere(
+        (s) => _sameStation(s.stop, leg.origin),
+      );
+      final destination = liveTrip.stopovers.lastIndexWhere(
+        (s) => _sameStation(s.stop, leg.destination),
+      );
+      if (origin >= 0 && destination > origin) {
+        for (final stop in liveTrip.stopovers.sublist(
+          origin,
+          destination + 1,
+        )) {
+          _addPoint(
+            points,
+            stop.stop,
+            stop.plannedDeparture ??
+                stop.plannedArrival ??
+                _planned(
+                  stop.departure ?? stop.arrival,
+                  stop.departureDelay ?? stop.arrivalDelay,
+                ),
+            stop.departureDelay ?? stop.arrivalDelay ?? 0,
+          );
+        }
+      }
+    }
+
+    if (points.length < 2) {
+      points.clear();
+      _addPoint(
+        points,
+        leg.origin,
+        leg.plannedDeparture ??
+            _planned(leg.departure, leg.departureDelay) ??
+            leg.departure,
+        leg.departureDelay ?? 0,
+      );
+      for (final stop in leg.stopovers) {
+        _addPoint(
+          points,
+          stop.stop,
+          _planned(
+                stop.departure ?? stop.arrival,
+                stop.departureDelay ?? stop.arrivalDelay,
+              ) ??
+              stop.departure ??
+              stop.arrival,
+          stop.departureDelay ?? stop.arrivalDelay ?? 0,
+        );
+      }
+      _addPoint(
+        points,
+        leg.destination,
+        leg.plannedArrival ??
+            _planned(leg.arrival, leg.arrivalDelay) ??
+            leg.arrival,
+        leg.arrivalDelay ?? 0,
+      );
+    }
+
+    // Remove duplicates and malformed/reversed times: the inference assumes a
+    // monotonically increasing timetable.
+    final clean = <TimedRoutePoint>[];
+    for (final point in points) {
+      if (clean.isNotEmpty &&
+          !point.scheduledAt.isAfter(clean.last.scheduledAt)) {
+        continue;
+      }
+      clean.add(point);
+    }
+    return clean;
+  }
+
+  static void _addPoint(
+    List<TimedRoutePoint> out,
+    Station station,
+    DateTime? at,
+    int delay,
+  ) {
+    if (!station.hasLocation || at == null) return;
+    if (out.isNotEmpty &&
+        out.last.latitude == station.latitude &&
+        out.last.longitude == station.longitude) {
+      return;
+    }
+    out.add(
+      TimedRoutePoint(
+        latitude: station.latitude!,
+        longitude: station.longitude!,
+        scheduledAt: at,
+        reportedDelaySeconds: delay,
+      ),
+    );
+  }
+
+  static bool _sameStation(Station a, Station b) =>
+      a.id.isNotEmpty && b.id.isNotEmpty ? a.id == b.id : a.name == b.name;
+
+  static DateTime? _planned(DateTime? live, int? delaySeconds) =>
+      live == null ? null : live.subtract(Duration(seconds: delaySeconds ?? 0));
+}
+
+/// Owns persistence and notification decisions for the background stream.
+/// Network access is intentionally absent: the last live timetable snapshot is
+/// enough to keep the exit alarm useful in a tunnel or after process death.
+class BackgroundTripTracking {
+  BackgroundTripTracking._();
+
+  static const _intelligence = ExitAlarmIntelligence();
+
+  static Future<void> registerHeadlessCallback() async {
+    try {
+      await LibreLocation.registerHeadlessDispatcher(
+        exitAlarmHeadlessDispatcher,
+        exitAlarmHeadlessLocation,
+      );
+    } catch (e) {
+      AppLog.log('headless location registration failed ($e)', tag: 'live');
+    }
+  }
+
+  static Future<void> writePlan(BackgroundJourneyPlan plan) async {
+    final prefs = await SharedPreferences.getInstance();
+    final oldJourney = _decode(prefs.getString(_planKey))?['journeyKey'];
+    await prefs.setString(_planKey, jsonEncode(plan.toJson()));
+    if (oldJourney != plan.journeyKey) await prefs.remove(_stateKey);
+  }
+
+  static Future<void> clearPlan() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_planKey);
+    await prefs.remove(_stateKey);
+  }
+
+  static Future<void> processPosition(Position position) => processSample(
+    JourneyPositionSample(
+      latitude: position.latitude,
+      longitude: position.longitude,
+      accuracy: position.accuracy,
+      speed: position.speed,
+      timestamp: position.timestamp,
+    ),
+  );
+
+  static Future<void> processPositionMap(Map<String, dynamic> data) async {
+    try {
+      await processPosition(Position.fromMap(data));
+    } catch (e) {
+      AppLog.log('headless location ignored ($e)', tag: 'live');
+    }
+  }
+
+  static Future<void> processSample(JourneyPositionSample sample) async {
+    final prefs = await SharedPreferences.getInstance();
+    // Headless and UI isolates have separate caches.
+    await prefs.reload();
+    final planJson = _decode(prefs.getString(_planKey));
+    if (planJson == null) return;
+
+    late final BackgroundJourneyPlan plan;
+    try {
+      plan = BackgroundJourneyPlan.fromJson(planJson);
+    } catch (_) {
+      return;
+    }
+    if (plan.legs.isEmpty) return;
+
+    TrackedJourneyLeg? selected;
+    JourneyPositionInference? inference;
+    final inferences = <String, JourneyPositionInference>{};
+    for (final leg in plan.legs) {
+      final candidate = _intelligence.evaluate(leg, sample);
+      if (candidate == null) continue;
+      inferences[leg.id] = candidate;
+      if (inference == null ||
+          candidate.distanceToRouteMetres < inference.distanceToRouteMetres) {
+        selected = leg;
+        inference = candidate;
+      }
+    }
+    if (selected == null || inference == null) return;
+
+    final state = _TrackingState.fromJson(_decode(prefs.getString(_stateKey)));
+    if (state.journeyKey != plan.journeyKey) {
+      state.resetJourney(plan.journeyKey);
+    }
+    if (state.legId != selected.id) state.switchLeg(selected.id);
+
+    MissedConnectionRescue? missedRescue;
+    for (final leg in plan.legs) {
+      final rescue = plan.rescues[leg.id];
+      if (rescue == null || state.missedPromptedLegs.contains(leg.id)) continue;
+      final effectiveDeparture = leg.departure.add(
+        Duration(seconds: leg.route.first.reportedDelaySeconds),
+      );
+      final grace = rescue.isConnection
+          ? const Duration(minutes: 3)
+          : const Duration(minutes: 8);
+      final inWindow =
+          sample.timestamp.isAfter(effectiveDeparture.add(grace)) &&
+          sample.timestamp.isBefore(
+            effectiveDeparture.add(const Duration(minutes: 35)),
+          );
+      final outgoing = inferences[leg.id];
+      final clearlyBoarded = outgoing != null && outgoing.progress >= .04;
+      // For an Anschluss, still matching another leg after its departure is
+      // the strong signal. For the first train, remaining at the route origin
+      // is necessarily more ambiguous, hence the longer grace above. We ask
+      // the rider; we never silently replace the journey.
+      final plausible =
+          inWindow &&
+          !clearlyBoarded &&
+          (rescue.isConnection ? selected.id != leg.id : selected.id == leg.id);
+      state.missedEvidence[leg.id] = plausible
+          ? (state.missedEvidence[leg.id] ?? 0) + 1
+          : 0;
+      if ((state.missedEvidence[leg.id] ?? 0) >= 2) {
+        state.missedPromptedLegs.add(leg.id);
+        missedRescue = rescue;
+        break;
+      }
+    }
+
+    final forward =
+        state.lastProgress == null ||
+        inference.progress >= state.lastProgress! - .015;
+    if (missedRescue == null &&
+        !inference.shouldNotifyExit &&
+        inference.progress >= .05 &&
+        inference.progress <= .97 &&
+        inference.suggestsUnreportedDelay &&
+        forward) {
+      state.delayEvidence++;
+    } else {
+      state.delayEvidence = 0;
+    }
+    state.lastProgress = inference.progress;
+
+    final delayBucket = (inference.inferredDelayMinutes ~/ 5) * 5;
+    final notifyDelay =
+        state.delayEvidence >= 2 &&
+        delayBucket >= 5 &&
+        delayBucket > (state.delayBuckets[selected.id] ?? 0);
+    final notifyExit =
+        inference.shouldNotifyExit &&
+        !state.exitNotifiedLegs.contains(selected.id);
+    if (notifyDelay) state.delayBuckets[selected.id] = delayBucket;
+    if (notifyExit) state.exitNotifiedLegs.add(selected.id);
+
+    // Persist before posting: if Android kills the headless isolate midway, a
+    // restarted callback must not ring twice.
+    await prefs.setString(_stateKey, jsonEncode(state.toJson()));
+
+    if (missedRescue != null) {
+      await NotificationService.showMissedConnectionPrompt(
+        id: _stableId(
+          'position-missed:${plan.journeyKey}:${missedRescue.legIndex}',
+        ),
+        rescue: missedRescue,
+      );
+      AppLog.log('position suggests ${missedRescue.label}', tag: 'live');
+    }
+
+    if (notifyDelay) {
+      final known = inference.reportedDelayMinutes;
+      final comparison = known <= 0
+          ? 'DB meldet dafür bislang noch keine Verspätung.'
+          : 'DB meldet bislang nur +$known Min.';
+      await NotificationService.showTripAlert(
+        id: _stableId('position-delay:${plan.journeyKey}:${selected.id}'),
+        title: 'Mögliche Verspätung: etwa +$delayBucket Min',
+        body: 'Deine Position passt nicht mehr zum Fahrplan. $comparison',
+      );
+      AppLog.log('position inferred +$delayBucket min', tag: 'live');
+    }
+
+    if (notifyExit) {
+      final title = 'Gleich aussteigen: ${selected.destinationName}';
+      final body = inference.inferredDelayMinutes >= 5
+          ? 'Deine Position zeigt: Ziel in Kürze — trotz Verspätung.'
+          : 'Deine Position zeigt: Du bist fast da. Sachen schnappen!';
+      if (plan.ringAlarm) {
+        await NotificationService.showExitAlarm(
+          id: _stableId('position-exit:${plan.journeyKey}:${selected.id}'),
+          title: title,
+          body: body,
+        );
+      } else {
+        await NotificationService.showTripAlert(
+          id: _stableId('position-exit:${plan.journeyKey}:${selected.id}'),
+          title: title,
+          body: body,
+        );
+      }
+      AppLog.log(
+        'background exit alert near ${selected.destinationName}',
+        tag: 'live',
+      );
+    }
+  }
+
+  static Map<String, dynamic>? _decode(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      return jsonDecode(raw) as Map<String, dynamic>;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static int _stableId(String value) {
+    var hash = 0x811c9dc5;
+    for (final unit in value.codeUnits) {
+      hash = ((hash ^ unit) * 0x01000193) & 0x7fffffff;
+    }
+    return hash;
+  }
+}
+
+class _TrackingState {
+  String? journeyKey;
+  String? legId;
+  double? lastProgress;
+  int delayEvidence;
+  final Map<String, int> delayBuckets;
+  final Set<String> exitNotifiedLegs;
+  final Map<String, int> missedEvidence;
+  final Set<String> missedPromptedLegs;
+
+  _TrackingState({
+    this.journeyKey,
+    this.legId,
+    this.lastProgress,
+    this.delayEvidence = 0,
+    Map<String, int>? delayBuckets,
+    Set<String>? exitNotifiedLegs,
+    Map<String, int>? missedEvidence,
+    Set<String>? missedPromptedLegs,
+  }) : delayBuckets = delayBuckets ?? <String, int>{},
+       exitNotifiedLegs = exitNotifiedLegs ?? <String>{},
+       missedEvidence = missedEvidence ?? <String, int>{},
+       missedPromptedLegs = missedPromptedLegs ?? <String>{};
+
+  factory _TrackingState.fromJson(Map<String, dynamic>? json) => _TrackingState(
+    journeyKey: json?['journeyKey'] as String?,
+    legId: json?['legId'] as String?,
+    lastProgress: (json?['lastProgress'] as num?)?.toDouble(),
+    delayEvidence: (json?['delayEvidence'] as num?)?.toInt() ?? 0,
+    delayBuckets:
+        (json?['delayBuckets'] as Map?)?.map(
+          (key, value) => MapEntry(key.toString(), (value as num).toInt()),
+        ) ??
+        <String, int>{},
+    exitNotifiedLegs:
+        (json?['exitNotifiedLegs'] as List<dynamic>? ?? const <dynamic>[])
+            .whereType<String>()
+            .toSet(),
+    missedEvidence:
+        (json?['missedEvidence'] as Map?)?.map(
+          (key, value) => MapEntry(key.toString(), (value as num).toInt()),
+        ) ??
+        <String, int>{},
+    missedPromptedLegs:
+        (json?['missedPromptedLegs'] as List<dynamic>? ?? const <dynamic>[])
+            .whereType<String>()
+            .toSet(),
+  );
+
+  void resetJourney(String journey) {
+    journeyKey = journey;
+    legId = null;
+    lastProgress = null;
+    delayEvidence = 0;
+    delayBuckets.clear();
+    exitNotifiedLegs.clear();
+    missedEvidence.clear();
+    missedPromptedLegs.clear();
+  }
+
+  void switchLeg(String leg) {
+    legId = leg;
+    lastProgress = null;
+    delayEvidence = 0;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'journeyKey': journeyKey,
+    'legId': legId,
+    'lastProgress': lastProgress,
+    'delayEvidence': delayEvidence,
+    'delayBuckets': delayBuckets,
+    'exitNotifiedLegs': exitNotifiedLegs.toList(),
+    'missedEvidence': missedEvidence,
+    'missedPromptedLegs': missedPromptedLegs.toList(),
+  };
+}

--- a/flutter-app/lib/services/background_trip_tracking.dart
+++ b/flutter-app/lib/services/background_trip_tracking.dart
@@ -228,7 +228,7 @@ class BackgroundJourneyPlan {
       a.id.isNotEmpty && b.id.isNotEmpty ? a.id == b.id : a.name == b.name;
 
   static DateTime? _planned(DateTime? live, int? delaySeconds) =>
-      live == null ? null : live.subtract(Duration(seconds: delaySeconds ?? 0));
+      live?.subtract(Duration(seconds: delaySeconds ?? 0));
 }
 
 /// Owns persistence and notification decisions for the background stream.

--- a/flutter-app/lib/services/location_service.dart
+++ b/flutter-app/lib/services/location_service.dart
@@ -21,6 +21,36 @@ class UserFix {
 /// then returns a single fix. Keeps all the permission/error wording in one
 /// place so the UI just shows what we throw.
 class LocationService {
+  /// Request the explicit "always" grant needed by the GPS journey companion.
+  /// Android 11+ may open the app-permission page for this second step.
+  Future<void> ensureBackgroundPermission() async {
+    if (!await LibreLocation.isLocationServiceEnabled()) {
+      throw const LocationException(
+        'Standortdienste sind aus. Bitte in den Geräteeinstellungen aktivieren.',
+      );
+    }
+
+    var permission = await LibreLocation.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await LibreLocation.requestPermission();
+    }
+    if (permission == LocationPermission.deniedForever) {
+      throw const LocationException(
+        'Standortzugriff ist dauerhaft abgelehnt. Erlaube in den '
+        'App-Einstellungen „Immer“ bzw. „Jederzeit“.',
+      );
+    }
+    if (permission == LocationPermission.whileInUse) {
+      permission = await LibreLocation.requestAlwaysPermission();
+    }
+    if (permission != LocationPermission.always) {
+      throw const LocationException(
+        'Für den Hintergrundalarm bitte den Standortzugriff „Immer“ bzw. '
+        '„Jederzeit“ erlauben und den Schalter danach erneut aktivieren.',
+      );
+    }
+  }
+
   /// Resolve the current device position, requesting permission if needed.
   /// Throws [LocationException] with a user-facing German message on failure.
   Future<UserFix> currentFix() async {

--- a/flutter-app/lib/services/notification_service.dart
+++ b/flutter-app/lib/services/notification_service.dart
@@ -1,11 +1,14 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
 import '../core/app_log.dart';
+import '../core/missed_connection.dart';
 
 /// Thin wrapper around flutter_local_notifications for the OS notifications the
 /// app fires: one-shot results (e.g. "Split-Ticket-Analyse fertig"), live trip
@@ -18,6 +21,15 @@ class NotificationService {
   static final _plugin = FlutterLocalNotificationsPlugin();
   static bool _ready = false;
   static bool _exactAlarms = false;
+  static const _missedPayloadPrefix = 'missed-connection:';
+  static const _pendingMissedKey = 'pending_missed_connection_v1';
+  static final _missedRescues =
+      StreamController<MissedConnectionRescue>.broadcast();
+
+  /// Emits when the rider taps "Alternativen suchen" while the app is alive.
+  /// Cold starts use [takePendingMissedRescue] instead.
+  static Stream<MissedConnectionRescue> get missedRescues =>
+      _missedRescues.stream;
 
   /// Lowest notification id used for *scheduled* trip reminders. Reserved range
   /// so [cancelReminders] can reconcile them without touching the one-shot
@@ -86,6 +98,11 @@ class NotificationService {
         // also run when the app cold-starts from a notification tap.
         onDidReceiveNotificationResponse: _onResponse,
       );
+      final launch = await _plugin.getNotificationAppLaunchDetails();
+      if (launch?.didNotificationLaunchApp == true &&
+          launch?.notificationResponse != null) {
+        await _handleResponse(launch!.notificationResponse!);
+      }
       final android_ = _plugin.resolvePlatformSpecificImplementation<
           AndroidFlutterLocalNotificationsPlugin>();
       await android_?.createNotificationChannel(_channel);
@@ -222,6 +239,54 @@ class NotificationService {
     }
   }
 
+  /// Ask rather than assert when GPS suggests that a train/connection was
+  /// missed. The affirmative action launches the app and carries the exact
+  /// station from which alternatives should be searched.
+  static Future<void> showMissedConnectionPrompt({
+    required int id,
+    required MissedConnectionRescue rescue,
+  }) async {
+    if (!_ready) await init();
+    await _ensurePermission();
+    try {
+      final details = NotificationDetails(
+        android: AndroidNotificationDetails(
+          'trip_alerts',
+          'Reise-Hinweise',
+          channelDescription:
+              'Abfahrts-Erinnerungen, Verspätungen und Umstiege',
+          importance: Importance.high,
+          priority: Priority.high,
+          actions: const <AndroidNotificationAction>[
+            AndroidNotificationAction(
+              'missed_alternatives',
+              'Alternativen suchen',
+              showsUserInterface: true,
+              cancelNotification: true,
+            ),
+            AndroidNotificationAction(
+              'missed_no',
+              'Nein',
+              cancelNotification: true,
+            ),
+          ],
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      );
+      await _plugin.show(
+        id: 4000 + (id % 1000),
+        title: '${rescue.label}?',
+        body: 'Deine Position spricht dafür. Jetzt Alternativen ab '
+            '${rescue.from.name} suchen?',
+        notificationDetails: details,
+        payload: '$_missedPayloadPrefix${rescue.encode()}',
+      );
+    } catch (e) {
+      AppLog.log('missed connection prompt failed ($e)', tag: 'notify');
+    }
+  }
+
   // ---- Scheduled trip reminders (planned offline from the timetable) ----
 
   /// Schedule a reminder to fire at [when] (a wall-clock instant in the local
@@ -352,6 +417,41 @@ class NotificationService {
   static void _onResponse(NotificationResponse r) {
     if (r.actionId == 'stop_alarm') {
       AppLog.log('arrival alarm stopped by user', tag: 'notify');
+    }
+    unawaited(_handleResponse(r));
+  }
+
+  static Future<void> _handleResponse(NotificationResponse response) async {
+    final payload = response.payload;
+    if (payload == null || !payload.startsWith(_missedPayloadPrefix)) return;
+    if (response.actionId == 'missed_no') return;
+    if (response.actionId != null &&
+        response.actionId!.isNotEmpty &&
+        response.actionId != 'missed_alternatives') {
+      return;
+    }
+    try {
+      final raw = payload.substring(_missedPayloadPrefix.length);
+      final rescue = MissedConnectionRescue.decode(raw);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_pendingMissedKey, raw);
+      _missedRescues.add(rescue);
+    } catch (e) {
+      AppLog.log('missed notification payload invalid ($e)', tag: 'notify');
+    }
+  }
+
+  /// Consume a rescue tap persisted before the Flutter UI was ready.
+  static Future<MissedConnectionRescue?> takePendingMissedRescue() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final raw = prefs.getString(_pendingMissedKey);
+    if (raw == null) return null;
+    await prefs.remove(_pendingMissedKey);
+    try {
+      return MissedConnectionRescue.decode(raw);
+    } catch (_) {
+      return null;
     }
   }
 }

--- a/flutter-app/test/exit_alarm_intelligence_test.dart
+++ b/flutter-app/test/exit_alarm_intelligence_test.dart
@@ -1,0 +1,111 @@
+import 'package:besser_bahn/core/exit_alarm_intelligence.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const intelligence = ExitAlarmIntelligence();
+  final departure = DateTime(2026, 7, 17, 10);
+  final arrival = DateTime(2026, 7, 17, 11);
+
+  TrackedJourneyLeg leg({int reportedDelaySeconds = 0}) => TrackedJourneyLeg(
+    id: 'ice-1',
+    lineName: 'ICE 1',
+    destinationName: 'Berlin Hbf',
+    route: [
+      TimedRoutePoint(
+        latitude: 52,
+        longitude: 13,
+        scheduledAt: departure,
+        reportedDelaySeconds: reportedDelaySeconds,
+      ),
+      TimedRoutePoint(
+        latitude: 52,
+        longitude: 14,
+        scheduledAt: arrival,
+        reportedDelaySeconds: reportedDelaySeconds,
+      ),
+    ],
+  );
+
+  JourneyPositionSample sample({
+    required double longitude,
+    required DateTime at,
+    double accuracy = 15,
+    double speed = 25,
+  }) => JourneyPositionSample(
+    latitude: 52,
+    longitude: longitude,
+    accuracy: accuracy,
+    speed: speed,
+    timestamp: at,
+  );
+
+  test('matches an on-time position to the timetable', () {
+    final result = intelligence.evaluate(
+      leg(),
+      sample(longitude: 13.5, at: departure.add(const Duration(minutes: 30))),
+    );
+
+    expect(result, isNotNull);
+    expect(result!.progress, closeTo(.5, .01));
+    expect(result.inferredDelayMinutes, 0);
+    expect(result.suggestsUnreportedDelay, isFalse);
+  });
+
+  test('spots position delay DB has not reported', () {
+    final result = intelligence.evaluate(
+      leg(),
+      sample(longitude: 13.5, at: departure.add(const Duration(minutes: 42))),
+    );
+
+    expect(result!.inferredDelayMinutes, 12);
+    expect(result.reportedDelayMinutes, 0);
+    expect(result.suggestsUnreportedDelay, isTrue);
+  });
+
+  test('does not call an already reported delay unreported', () {
+    final result = intelligence.evaluate(
+      leg(reportedDelaySeconds: 10 * 60),
+      sample(longitude: 13.5, at: departure.add(const Duration(minutes: 42))),
+    );
+
+    expect(result!.inferredDelayMinutes, 12);
+    expect(result.reportedDelayMinutes, 10);
+    expect(result.suggestsUnreportedDelay, isFalse);
+  });
+
+  test('uses speed-aware but bounded destination corridor', () {
+    final result = intelligence.evaluate(
+      leg(),
+      sample(
+        longitude: 13.98,
+        at: arrival.add(const Duration(minutes: 8)),
+        speed: 30,
+      ),
+    );
+
+    expect(result!.distanceToDestinationMetres, lessThan(2500));
+    expect(result.shouldNotifyExit, isTrue);
+  });
+
+  test('rejects an inaccurate fix', () {
+    final result = intelligence.evaluate(
+      leg(),
+      sample(
+        longitude: 13.5,
+        at: departure.add(const Duration(minutes: 30)),
+        accuracy: 500,
+      ),
+    );
+
+    expect(result, isNull);
+  });
+
+  test('cannot alarm at destination before departure', () {
+    final result = intelligence.evaluate(
+      leg(),
+      sample(longitude: 14, at: departure.subtract(const Duration(minutes: 5))),
+    );
+
+    expect(result, isNull);
+  });
+}

--- a/flutter-app/test/missed_connection_test.dart
+++ b/flutter-app/test/missed_connection_test.dart
@@ -1,0 +1,85 @@
+import 'package:besser_bahn/core/missed_connection.dart';
+import 'package:besser_bahn/models/departure.dart';
+import 'package:besser_bahn/models/journey.dart';
+import 'package:besser_bahn/models/station.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const a = Station(id: '1', name: 'A');
+  const b = Station(id: '2', name: 'B');
+  const c = Station(id: '3', name: 'C');
+  const line = TransitLine(
+    name: 'ICE 1',
+    fahrtNr: '1',
+    productName: 'ICE',
+    product: 'nationalExpress',
+  );
+  final ten = DateTime(2026, 7, 17, 10);
+  final journey = Journey(
+    legs: [
+      JourneyLeg(
+        origin: a,
+        destination: b,
+        departure: ten,
+        arrival: ten.add(const Duration(hours: 1)),
+        line: line,
+      ),
+      JourneyLeg(
+        origin: b,
+        destination: c,
+        departure: ten.add(const Duration(hours: 1, minutes: 10)),
+        arrival: ten.add(const Duration(hours: 2)),
+        line: line,
+      ),
+    ],
+  );
+
+  test('offers rescue from the original origin around first departure', () {
+    final rescue = MissedConnectionRescue.forJourney(
+      journey,
+      now: ten.add(const Duration(minutes: 5)),
+    );
+
+    expect(rescue, isNotNull);
+    expect(rescue!.from.id, a.id);
+    expect(rescue.to.id, c.id);
+    expect(rescue.isConnection, isFalse);
+  });
+
+  test('offers rescue from transfer station for missed connection', () {
+    final rescue = MissedConnectionRescue.forJourney(
+      journey,
+      now: ten.add(const Duration(hours: 1, minutes: 15)),
+    );
+
+    expect(rescue, isNotNull);
+    expect(rescue!.from.id, b.id);
+    expect(rescue.to.id, c.id);
+    expect(rescue.isConnection, isTrue);
+  });
+
+  test('hides the action outside the plausible missed window', () {
+    final rescue = MissedConnectionRescue.forJourney(
+      journey,
+      now: ten.subtract(const Duration(hours: 2)),
+    );
+
+    expect(rescue, isNull);
+  });
+
+  test('notification payload round-trips stations and leg', () {
+    final rescue = MissedConnectionRescue(
+      from: b,
+      to: c,
+      scheduledDeparture: ten,
+      legIndex: 1,
+      isConnection: true,
+    );
+
+    final decoded = MissedConnectionRescue.decode(rescue.encode());
+    expect(decoded.from.id, b.id);
+    expect(decoded.to.id, c.id);
+    expect(decoded.legIndex, 1);
+    expect(decoded.isConnection, isTrue);
+  });
+}


### PR DESCRIPTION
## Zusammenfassung

- führt die GPS-Reisebegleitung als sichtbaren, stromsparenden Hintergrunddienst für aktiv überwachte Reisen weiter (inklusive Prozessende und Neustart)
- kombiniert Fahrplan, bekannte Echtzeitverspätung und Positionsfortschritt; erst zwei konsistente Messungen erzeugen einen Hinweis auf eine möglicherweise noch nicht gemeldete Verspätung
- warnt positionsbasiert vor dem Ausstieg; ein echter, anhaltender Klingelalarm wird nur mit der separaten Einstellung „Laut klingeln“ verwendet
- ergänzt im passenden Zeitfenster „Verpasst“ in der geöffneten Reise und sucht beim ersten Zug ab dem Start, bei einem Anschluss ab dem Umstiegsbahnhof
- fragt bei einer vorsichtig erkannten verpassten Abfahrt per Benachrichtigung nach; „Alternativen suchen“ öffnet direkt die vorbereitete Suche, „Nein“ verwirft den Vorschlag
- dokumentiert die ausschließlich lokale Verarbeitung des optionalen Hintergrundstandorts

## Umsetzungshinweise

- kein zusätzlicher Server und kein GPS-Upload; der letzte lokale Fahrplan-Snapshot reicht auch ohne Netz
- Android nutzt den vorhandenen GMS-freien `libre_location`-Dienst mit Always-Permission, Foreground-Service-Benachrichtigung, Boot-Neustart und Headless-Callback
- GPS-Ausreißer über 250 m Genauigkeit werden verworfen; Benachrichtigungen und Alarmzustände werden persistent dedupliziert
- die automatische „Verpasst“-Erkennung bucht oder ersetzt nie selbstständig eine Verbindung

## Tests

- `flutter analyze --no-fatal-infos` ✅ (nur bereits vorhandene projektweite Info-Hinweise)
- 10 neue Unit-Tests für Positions-/Verspätungslogik, Ausstiegskorridor, Verpasst-Zeitfenster, Umstiegsbahnhof und Notification-Payload ✅
- `flutter build apk --debug` mit Flutter 3.41.9 ✅
- vollständiger Lauf: 469 Tests bestanden; 3 bestehende, zeitzonenabhängige Vendo-Tests erwarten auf dem UTC-Runner Stunde `0`, erhalten für dieselben Zeitpunkte Stunde `22` (keine der betroffenen Dateien wurde geändert)