### PR TITLE
fix(android): OAuth-Browser nach Anmeldung schließen

### DIFF
--- a/flutter-app/android/app/build.gradle.kts
+++ b/flutter-app/android/app/build.gradle.kts
@@ -112,5 +112,6 @@ flutter {
 }
 
 dependencies {
+    implementation("androidx.browser:browser:1.9.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/flutter-app/android/app/src/main/AndroidManifest.xml
+++ b/flutter-app/android/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <!-- OAuth callbacks for flutter_web_auth_2:
+        <!-- OAuth callbacks for the Android classic-Custom-Tab bridge:
              - besserbahn:// — Träwelling login (bahn.chuk.dev bounce page).
              - dbnav://     — Deutsche-Bahn account login; DB's Keycloak
                               redirects straight into the DB Navigator app
@@ -69,21 +69,26 @@
              - bahnbonus:// — separate BahnBonus OAuth token for the official
                               personal CO₂ statistics service.
 
-             `taskAffinity=""` is required by the plugin and was missing (#35).
-             Without it this activity inherits the application's affinity, while
-             MainActivity above declares an empty one — so the callback landed in
-             a DIFFERENT task than the app. The result still arrived (the plugin
-             hands it over in-process, which is why the login itself worked), but
-             the FLAG_ACTIVITY_CLEAR_TOP intent that dismisses the browser could
-             not find the waiting activity, leaving the Custom Tab spinning on
-             top until the user closed it by hand. An empty affinity puts the
-             callback in the same task family as MainActivity, so the browser
-             steps aside on its own. Same path serves Träwelling (#34). -->
+             Version 5 of flutter_web_auth_2 uses Chrome Auth Tab, which only
+             closes reliably with these custom schemes on recent browsers. The
+             local bridge deliberately uses a classic Custom Tab and brings its
+             management activity forward with CLEAR_TOP after the redirect. This
+             closes the browser on old and new Chrome versions without using an
+             ephemeral session (and therefore keeps DB login cookies). All three
+             activities use the empty task affinity so the callback can reach the
+             waiting activity in the same task (#35). -->
         <activity
-            android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
+            android:name=".OAuthManagementActivity"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
+            android:name=".OAuthCallbackActivity"
             android:exported="true"
+            android:excludeFromRecents="true"
             android:taskAffinity="">
-            <intent-filter android:label="flutter_web_auth_2">
+            <intent-filter android:label="Besser Bahn OAuth">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/MainActivity.kt
+++ b/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/MainActivity.kt
@@ -1,5 +1,65 @@
 package dev.chuk.betterbahn
 
+import android.app.Activity
+import android.content.Intent
+import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    companion object {
+        private const val OAUTH_CHANNEL = "dev.chuk.betterbahn/oauth"
+        private const val OAUTH_REQUEST = 7041
+    }
+
+    private var pendingOAuthResult: MethodChannel.Result? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, OAUTH_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                if (call.method != "authenticate") {
+                    result.notImplemented()
+                    return@setMethodCallHandler
+                }
+
+                val url = call.argument<String>("url")
+                val callbackScheme = call.argument<String>("callbackUrlScheme")
+                if (url.isNullOrBlank() || callbackScheme.isNullOrBlank()) {
+                    result.error("INVALID_ARGUMENT", "OAuth URL or callback scheme is missing", null)
+                    return@setMethodCallHandler
+                }
+                if (pendingOAuthResult != null) {
+                    result.error("AUTH_IN_PROGRESS", "An OAuth login is already in progress", null)
+                    return@setMethodCallHandler
+                }
+
+                pendingOAuthResult = result
+                startActivityForResult(
+                    OAuthManagementActivity.createIntent(this, url, callbackScheme),
+                    OAUTH_REQUEST,
+                )
+            }
+    }
+
+    @Deprecated("Deprecated in Android, still required by FlutterActivity's result dispatch")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != OAUTH_REQUEST) return
+
+        val result = pendingOAuthResult ?: return
+        pendingOAuthResult = null
+        when (resultCode) {
+            Activity.RESULT_OK -> {
+                val callbackUrl = data?.getStringExtra(OAuthManagementActivity.EXTRA_CALLBACK_URL)
+                if (callbackUrl == null) {
+                    result.error("FAILED", "Authentication returned no callback URL", null)
+                } else {
+                    result.success(callbackUrl)
+                }
+            }
+            else -> result.error("CANCELED", "User canceled authentication", null)
+        }
+    }
+}

--- a/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/OAuthCallbackActivity.kt
+++ b/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/OAuthCallbackActivity.kt
@@ -1,0 +1,15 @@
+package dev.chuk.betterbahn
+
+import android.app.Activity
+import android.os.Bundle
+
+/** Receives DB, BahnBonus and Träwelling redirects and closes their Custom Tab. */
+class OAuthCallbackActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        intent?.data?.toString()?.let { callbackUrl ->
+            startActivity(OAuthManagementActivity.createCallbackIntent(this, callbackUrl))
+        }
+        finish()
+    }
+}

--- a/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/OAuthManagementActivity.kt
+++ b/flutter-app/android/app/src/main/kotlin/dev/chuk/betterbahn/OAuthManagementActivity.kt
@@ -1,0 +1,95 @@
+package dev.chuk.betterbahn
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+
+/**
+ * Owns the classic Custom Tab used for OAuth on Android.
+ *
+ * flutter_web_auth_2 5.x uses Chrome Auth Tab, whose custom-scheme callback
+ * does not dismiss reliably on Chrome versions before 141. Bringing this
+ * activity back to the front with CLEAR_TOP closes the classic Custom Tab
+ * while retaining the browser's normal cookie session.
+ */
+class OAuthManagementActivity : Activity() {
+    companion object {
+        const val EXTRA_CALLBACK_URL = "callbackUrl"
+        private const val EXTRA_AUTH_URL = "authUrl"
+        private const val EXTRA_CALLBACK_SCHEME = "callbackScheme"
+        private const val STATE_AUTH_STARTED = "authStarted"
+
+        fun createIntent(context: Context, url: String, callbackScheme: String) =
+            Intent(context, OAuthManagementActivity::class.java).apply {
+                putExtra(EXTRA_AUTH_URL, url)
+                putExtra(EXTRA_CALLBACK_SCHEME, callbackScheme)
+            }
+
+        fun createCallbackIntent(context: Context, callbackUrl: String) =
+            Intent(context, OAuthManagementActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                putExtra(EXTRA_CALLBACK_URL, callbackUrl)
+            }
+    }
+
+    private var authStarted = false
+    private var callbackUrl: String? = null
+    private lateinit var authUrl: String
+    private lateinit var callbackScheme: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        authUrl = intent.getStringExtra(EXTRA_AUTH_URL).orEmpty()
+        callbackScheme = intent.getStringExtra(EXTRA_CALLBACK_SCHEME).orEmpty()
+        authStarted = savedInstanceState?.getBoolean(STATE_AUTH_STARTED) ?: false
+        if (authUrl.isBlank() || callbackScheme.isBlank()) {
+            cancel()
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        callbackUrl = intent.getStringExtra(EXTRA_CALLBACK_URL)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isFinishing) return
+
+        if (!authStarted) {
+            authStarted = true
+            try {
+                val customTab = CustomTabsIntent.Builder().build()
+                CustomTabsClient.getPackageName(this, emptyList())?.let {
+                    customTab.intent.setPackage(it)
+                }
+                customTab.launchUrl(this, Uri.parse(authUrl))
+            } catch (_: Exception) {
+                cancel()
+            }
+            return
+        }
+
+        val returnedUrl = callbackUrl
+        if (returnedUrl != null && Uri.parse(returnedUrl).scheme == callbackScheme) {
+            setResult(RESULT_OK, Intent().putExtra(EXTRA_CALLBACK_URL, returnedUrl))
+            finish()
+        } else {
+            cancel()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_AUTH_STARTED, authStarted)
+    }
+
+    private fun cancel() {
+        setResult(RESULT_CANCELED)
+        finish()
+    }
+}

--- a/flutter-app/lib/services/db_account_service.dart
+++ b/flutter-app/lib/services/db_account_service.dart
@@ -7,7 +7,6 @@ import 'package:crypto/crypto.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -16,6 +15,7 @@ import '../core/constants.dart';
 import '../core/request_coalescer.dart';
 import '../models/db_account.dart';
 import '../models/db_ticket.dart';
+import 'oauth_browser.dart';
 
 /// Result of a refresh-token call.
 enum _RefreshOutcome { success, transient, rejected }
@@ -174,7 +174,7 @@ class DbAccountService {
     );
 
     AppLog.log('login → ${DbAccountConstants.authorizeUrl}', tag: 'db-account');
-    final result = await FlutterWebAuth2.authenticate(
+    final result = await OAuthBrowser.authenticate(
       url: authUrl.toString(),
       callbackUrlScheme: DbAccountConstants.callbackScheme,
     );
@@ -397,7 +397,7 @@ class DbAccountService {
         'kc_locale': 'de',
       },
     );
-    final result = await FlutterWebAuth2.authenticate(
+    final result = await OAuthBrowser.authenticate(
       url: authUrl.toString(),
       callbackUrlScheme: DbAccountConstants.bahnbonusCallbackScheme,
     );

--- a/flutter-app/lib/services/oauth_browser.dart
+++ b/flutter-app/lib/services/oauth_browser.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+
+/// Opens OAuth and returns the provider's callback URL.
+///
+/// Android uses a classic Custom Tab so custom-scheme redirects also dismiss
+/// the browser on Chrome < 141. Other platforms keep their native
+/// flutter_web_auth_2 implementation.
+class OAuthBrowser {
+  static const _androidChannel = MethodChannel('dev.chuk.betterbahn/oauth');
+
+  static Future<String> authenticate({
+    required String url,
+    required String callbackUrlScheme,
+  }) async {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      final result = await _androidChannel.invokeMethod<String>(
+        'authenticate',
+        {'url': url, 'callbackUrlScheme': callbackUrlScheme},
+      );
+      if (result == null) {
+        throw const PlatformException(
+          code: 'FAILED',
+          message: 'Authentication returned no callback URL',
+        );
+      }
+      return result;
+    }
+
+    return FlutterWebAuth2.authenticate(
+      url: url,
+      callbackUrlScheme: callbackUrlScheme,
+    );
+  }
+}

--- a/flutter-app/lib/services/oauth_browser.dart
+++ b/flutter-app/lib/services/oauth_browser.dart
@@ -20,7 +20,7 @@ class OAuthBrowser {
         {'url': url, 'callbackUrlScheme': callbackUrlScheme},
       );
       if (result == null) {
-        throw const PlatformException(
+        throw PlatformException(
           code: 'FAILED',
           message: 'Authentication returned no callback URL',
         );

--- a/flutter-app/lib/services/traewelling_service.dart
+++ b/flutter-app/lib/services/traewelling_service.dart
@@ -4,12 +4,12 @@ import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:http/http.dart' as http;
 
 import '../core/constants.dart';
 import '../core/user_agent_client.dart';
 import '../models/traewelling_models.dart';
+import 'oauth_browser.dart';
 
 /// Raised when an API call fails. [status] carries the HTTP code so callers can
 /// special-case 401 (re-login) and 409 (check-in collision).
@@ -167,7 +167,7 @@ class TraewellingService {
       },
     );
 
-    final result = await FlutterWebAuth2.authenticate(
+    final result = await OAuthBrowser.authenticate(
       url: authUrl.toString(),
       callbackUrlScheme: TraewellingConstants.callbackScheme,
     );

--- a/flutter-app/test/oauth_browser_test.dart
+++ b/flutter-app/test/oauth_browser_test.dart
@@ -1,0 +1,54 @@
+import 'package:besser_bahn/services/oauth_browser.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('dev.chuk.betterbahn/oauth');
+
+  tearDown(() async {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'Android sends OAuth requests through the classic Custom Tab bridge',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      MethodCall? received;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            received = call;
+            return 'dbnav://dbnavigator.bahn.de/login/success?code=abc';
+          });
+
+      final result = await OAuthBrowser.authenticate(
+        url: 'https://accounts.bahn.de/auth',
+        callbackUrlScheme: 'dbnav',
+      );
+
+      expect(result, contains('code=abc'));
+      expect(received?.method, 'authenticate');
+      expect(received?.arguments, {
+        'url': 'https://accounts.bahn.de/auth',
+        'callbackUrlScheme': 'dbnav',
+      });
+    },
+  );
+
+  test('Android rejects an empty native callback result', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => null);
+
+    expect(
+      OAuthBrowser.authenticate(
+        url: 'https://example.com/auth',
+        callbackUrlScheme: 'besserbahn',
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Zusammenfassung

- ersetzt auf Android den Auth-Tab aus `flutter_web_auth_2` durch einen kleinen lokalen Classic-Custom-Tab-Bridge
- bringt nach `dbnav://`, `besserbahn://` oder `bahnbonus://` die wartende Activity mit `CLEAR_TOP` nach vorn und schließt damit den Browser automatisch
- behält normale Browser-Cookies bei; DB-Sitzungen werden nicht durch einen Ephemeral-Workaround verworfen
- lässt iOS, Web und Desktop weiterhin unverändert über `flutter_web_auth_2` laufen

Closes #35

## Hintergrund

`flutter_web_auth_2` 5.x verwendet auf Android den neuen Auth Tab, dessen Custom-Scheme-Rücksprung laut Issue-Diagnose erst mit neueren Browser-Versionen zuverlässig schließt. Ein Downgrade auf 4.1.0 scheitert dagegen am aktuellen Android/Kotlin-Toolchain. Die lokale Android-Anpassung übernimmt daher nur den bewährten Classic-Custom-Tab-Ablauf, ohne das alte Plugin zu forken oder dessen veraltete Build-Konfiguration einzubinden.

Der gemeinsame Callback-Pfad deckt DB, Träwelling und BahnBonus ab.

## Tests

- `dart format --output=none --set-exit-if-changed lib/services/oauth_browser.dart test/oauth_browser_test.dart`
- `flutter analyze --no-fatal-infos`
- `flutter test test/oauth_browser_test.dart`
- `flutter build apk --debug`

Alle Prüfungen sind im separaten [CI-Lauf](https://github.com/grosserknallkopf/Besser-Bahn/actions/runs/29602465203) grün.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Android OAuth handling through Chrome Custom Tabs.
  * Improved support for OAuth callback schemes, including Besser Bahn, DB Navigator, and BahnBonus.
  * Added a unified authentication flow across Android, web, and other platforms.

* **Bug Fixes**
  * Improved callback handling when OAuth activities are recreated or cancelled.

* **Tests**
  * Added coverage for successful Android authentication and failed callback responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->