### PR TITLE
fix(split-ticket): unify discount & class state handling, add interac…

### DIFF
--- a/flutter-app/lib/providers/bulk_split_provider.dart
+++ b/flutter-app/lib/providers/bulk_split_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../models/journey.dart';
+import '../models/reisende.dart';
 import '../models/split_ticket.dart';
 import '../services/db_api_service.dart';
 import '../utils/split_engine.dart';
@@ -142,8 +143,14 @@ class BulkSplitNotifier extends Notifier<BulkSplitState> {
     final engine = SplitEngine(
         ref.read(vendoServiceProvider), ref.read(dbApiServiceProvider));
     final reisende = settings.searchParty.toReisendeJson();
-    final travellers =
-        DbApiService.createTravellerPayload(bahnCard: settings.bahnCard);
+    final primaryTraveler = settings.searchParty.travelers
+        .firstWhere((t) => t.typ.isPerson,
+            orElse: () => const Traveler(typ: TravelerType.erwachsener));
+    final travellers = DbApiService.createTravellerPayload(
+      bahnCard: primaryTraveler.bahnCard,
+      weitere: primaryTraveler.weitere,
+      sba: primaryTraveler.sba,
+    );
 
     final rows = <BulkSplitRow>[];
     for (final j in journeys) {

--- a/flutter-app/lib/providers/settings_provider.dart
+++ b/flutter-app/lib/providers/settings_provider.dart
@@ -170,15 +170,20 @@ class SettingsNotifier extends Notifier<AppSettings> {
   }
 
   void setBahnCard(BahnCardType card) {
-    // Setting "my" card re-seeds the party to a single adult with that card —
-    // the simple settings path for users who never open the advanced sheet. But
-    // once the party has been customised, leave it alone (#43): just carry the
-    // new card into the existing party.
+    final cardReduction = Reduction.byKey(card.vendoErmaessigung);
+    final travelers = state.searchParty.travelers.map((t) {
+      if (t.typ.isPerson) {
+        return t.copyWith(bahnCard: cardReduction);
+      }
+      return t;
+    }).toList();
+
     state = state.copyWith(
       bahnCard: card,
-      searchParty: state.partyCustomized
-          ? state.searchParty
-          : SearchParty.fromSettings(card, state.hasDeutschlandTicket),
+      searchParty: state.searchParty.copyWith(
+        firstClass: card.isFirstClass,
+        travelers: travelers,
+      ),
     );
     _save();
   }
@@ -187,6 +192,20 @@ class SettingsNotifier extends Notifier<AppSettings> {
     state = state.copyWith(
       hasDeutschlandTicket: value,
       searchParty: state.searchParty.copyWith(deutschlandTicket: value),
+    );
+    _save();
+  }
+
+  void setWeitereReduction(Reduction reduction) {
+    final travelers = state.searchParty.travelers.map((t) {
+      if (t.typ.isPerson) {
+        return t.copyWith(weitere: reduction);
+      }
+      return t;
+    }).toList();
+
+    state = state.copyWith(
+      searchParty: state.searchParty.copyWith(travelers: travelers),
     );
     _save();
   }

--- a/flutter-app/lib/providers/split_ticket_provider.dart
+++ b/flutter-app/lib/providers/split_ticket_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/reisende.dart';
 import '../models/split_ticket.dart';
 import '../services/db_api_service.dart';
 import '../services/notification_service.dart';
@@ -115,8 +116,15 @@ class SplitTicketNotifier extends Notifier<SplitTicketState> {
     final settings = ref.read(settingsProvider);
     final dbApi = ref.read(dbApiServiceProvider);
     final vendo = ref.read(vendoServiceProvider);
+    // Derive the fallback (DB web API) payload from the actual search party so
+    // Halbtax / Vorteilscard / SBA are not silently dropped when Vendo fails.
+    final primaryTraveler = settings.searchParty.travelers
+        .firstWhere((t) => t.typ.isPerson,
+            orElse: () => const Traveler(typ: TravelerType.erwachsener));
     final travellers = DbApiService.createTravellerPayload(
-      bahnCard: settings.bahnCard,
+      bahnCard: primaryTraveler.bahnCard,
+      weitere: primaryTraveler.weitere,
+      sba: primaryTraveler.sba,
     );
     // Price segments for the SAME party the search uses (age/type/BahnCard), so
     // youth/child fares match the DB app instead of always pricing an adult —
@@ -152,7 +160,7 @@ class SplitTicketNotifier extends Notifier<SplitTicketState> {
         reisende: partyReisende,
         travellers: travellers,
         deutschlandTicket: settings.hasDeutschlandTicket,
-        firstClass: settings.bahnCard.isFirstClass,
+        firstClass: settings.searchParty.firstClass,
         apiDelayMs: settings.apiDelayMs,
         // A newer analyze() (or cancel()) supersedes this run.
         isCancelled: () => myGen != _gen || state.isCancelled,

--- a/flutter-app/lib/screens/settings/settings_screen.dart
+++ b/flutter-app/lib/screens/settings/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/constants.dart';
 import '../../core/offline_package.dart';
+import '../../models/reisende.dart';
 import '../../models/split_ticket.dart';
 import '../../models/transfer_profile.dart';
 import '../../models/traewelling_models.dart';
@@ -284,6 +285,34 @@ class SettingsScreen extends ConsumerWidget {
                     }).toList(),
                   ),
                 ),
+                const Divider(height: 1),
+
+                // Weitere Ermäßigungen (Halbtax, Vorteilscard, etc.)
+                Builder(builder: (context) {
+                  final primaryTraveler = settings.searchParty.travelers
+                      .firstWhere((t) => t.typ.isPerson,
+                          orElse: () => const Traveler(typ: TravelerType.erwachsener));
+                  return ListTile(
+                    leading: const Icon(Icons.discount_outlined),
+                    title: const Text('Weitere Ermäßigung'),
+                    subtitle: const Text('Halbtax, Vorteilscard, NL-40 etc.'),
+                    trailing: DropdownButton<Reduction>(
+                      value: primaryTraveler.weitere,
+                      underline: const SizedBox(),
+                      onChanged: (v) {
+                        if (v != null) {
+                          notifier.setWeitereReduction(v);
+                        }
+                      },
+                      items: Reduction.weitereOptions.map((r) {
+                        return DropdownMenuItem(
+                          value: r,
+                          child: Text(r.label, style: const TextStyle(fontSize: 14)),
+                        );
+                      }).toList(),
+                    ),
+                  );
+                }),
                 const Divider(height: 1),
 
                 // Deutschland-Ticket

--- a/flutter-app/lib/screens/split_ticket/split_ticket_screen.dart
+++ b/flutter-app/lib/screens/split_ticket/split_ticket_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../models/journey.dart';
+import '../../models/reisende.dart';
 import '../../models/split_ticket.dart';
 import '../../providers/service_providers.dart';
 import '../../providers/split_ticket_provider.dart';
@@ -13,6 +14,7 @@ import '../../services/db_api_service.dart';
 import '../../utils/split_stops.dart';
 import '../../widgets/ui/message_card.dart';
 import '../../theme/app_colors.dart';
+import '../connection_search/widgets/reisende_sheet.dart';
 
 /// Split-ticket analysis viewer + entry point.
 ///
@@ -386,12 +388,20 @@ class _SplitTicketScreenState extends ConsumerState<SplitTicketScreen> {
     );
   }
 
-  /// Show the search assumptions so the price is unambiguous: which BahnCard
-  /// and whether a Deutschland-Ticket was applied (both from Einstellungen).
+  /// Show the search assumptions so the price is unambiguous: which BahnCard,
+  /// weitere Ermäßigungen (Halbtax, Vorteilscard, …), SBA, and whether a
+  /// Deutschland-Ticket was applied (all from Einstellungen).
   Widget _buildAssumptions(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final s = ref.watch(settingsProvider);
-    final hasBC = s.bahnCard != BahnCardType.none;
+    final primaryTraveler = s.searchParty.travelers
+        .firstWhere((t) => t.typ.isPerson,
+            orElse: () => const Traveler(typ: TravelerType.erwachsener));
+    final hasBC = primaryTraveler.bahnCard != Reduction.none;
+    final hasWeitere = primaryTraveler.weitere != Reduction.none;
+    final hasSba = primaryTraveler.sba != SbaOption.none;
+    final isDTicket = s.hasDeutschlandTicket;
+
     return Card(
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: Padding(
@@ -405,41 +415,81 @@ class _SplitTicketScreenState extends ConsumerState<SplitTicketScreen> {
                     size: 16, color: theme.colorScheme.onSurfaceVariant),
                 const SizedBox(width: 6),
                 Text('Preise gelten für', style: theme.textTheme.titleSmall),
+                const Spacer(),
+                TextButton.icon(
+                  style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    minimumSize: const Size(0, 32),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  icon: const Icon(Icons.edit, size: 14),
+                  label: const Text('Ändern', style: TextStyle(fontSize: 12)),
+                  onPressed: () async {
+                    final newParty = await showReisendeSheet(context, s.searchParty);
+                    if (newParty == null) return;
+                    ref.read(settingsProvider.notifier).setSearchParty(newParty);
+
+                    // Re-run the active analysis with the updated party
+                    if (journey != null) {
+                      final stops = splitStopsFromJourney(journey!);
+                      final dep = journey!.plannedDeparture ?? journey!.departure;
+                      final date = dep != null ? dep.toIso8601String().split('T').first : '';
+                      ref.read(splitTicketProvider.notifier).analyze(
+                        stops: stops,
+                        date: date,
+                        directPrice: journey!.price?.amount ?? 0,
+                        routeLabel: '${journey!.origin?.name ?? ''} → ${journey!.destination?.name ?? ''}',
+                        jobKey: 'rerun:${DateTime.now().millisecondsSinceEpoch}',
+                      );
+                    }
+                  },
+                ),
               ],
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 4),
             Wrap(
               spacing: 6,
               runSpacing: 4,
               children: [
                 Chip(
                   avatar: Icon(
-                      hasBC ? Icons.credit_card : Icons.credit_card_off,
-                      size: 16),
-                  label: Text(hasBC ? s.bahnCard.label : 'ohne BahnCard'),
+                      hasBC ? Icons.check_circle : Icons.credit_card_off,
+                      size: 16,
+                      color: hasBC ? AppColors.onTime : null),
+                  label: Text(hasBC ? primaryTraveler.bahnCard.label : 'ohne BahnCard'),
+                  backgroundColor: hasBC ? AppColors.onTime.withAlpha(20) : null,
                   materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   visualDensity: VisualDensity.compact,
                 ),
+                if (hasWeitere)
+                  Chip(
+                    avatar: const Icon(Icons.check_circle, size: 16, color: AppColors.onTime),
+                    label: Text(primaryTraveler.weitere.label),
+                    backgroundColor: AppColors.onTime.withAlpha(20),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                if (hasSba)
+                  Chip(
+                    avatar: const Icon(Icons.check_circle, size: 16, color: AppColors.onTime),
+                    label: Text(primaryTraveler.sba.label),
+                    backgroundColor: AppColors.onTime.withAlpha(20),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
                 Chip(
                   avatar: Icon(
-                      s.hasDeutschlandTicket
-                          ? Icons.check_circle
-                          : Icons.cancel,
+                      isDTicket ? Icons.check_circle : Icons.cancel,
                       size: 16,
-                      color: s.hasDeutschlandTicket ? AppColors.onTime : null),
-                  label: Text(s.hasDeutschlandTicket
+                      color: isDTicket ? AppColors.onTime : null),
+                  label: Text(isDTicket
                       ? 'mit Deutschland-Ticket'
                       : 'ohne Deutschland-Ticket'),
+                  backgroundColor: isDTicket ? AppColors.onTime.withAlpha(20) : null,
                   materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   visualDensity: VisualDensity.compact,
                 ),
               ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'In den Einstellungen änderbar.',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             ),
           ],
         ),

--- a/flutter-app/lib/services/db_api_service.dart
+++ b/flutter-app/lib/services/db_api_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../core/constants.dart';
+import '../models/reisende.dart';
 import '../models/split_ticket.dart';
 
 /// Service for Deutsche Bahn internal web API (bahn.de)
@@ -118,19 +119,58 @@ class DbApiService {
     }
   }
 
-  /// Create traveller payload for API
+  /// Create traveller payload for the bahn.de web API (DB fallback path).
+  ///
+  /// Accepts [bahnCard] (BahnCard reduction), [weitere] (foreign
+  /// railcards like Halbtax / Vorteilscard / NL-40), and [sba]
+  /// (Schwerbehindertenausweis) so the fallback matches the Vendo primary path.
   static List<Map<String, dynamic>> createTravellerPayload({
-    BahnCardType bahnCard = BahnCardType.none,
+    dynamic bahnCard = Reduction.none,
+    Reduction weitere = Reduction.none,   // e.g. Halbtax, Vorteilscard, NL-40
+    SbaOption sba = SbaOption.none,       // Schwerbehindertenausweis
   }) {
+    final ermaessigungen = <Map<String, dynamic>>[];
+
+    final card = bahnCard is BahnCardType
+        ? Reduction.byKey(bahnCard.vendoErmaessigung)
+        : (bahnCard is Reduction ? bahnCard : Reduction.none);
+
+    // BahnCard (primary DB card)
+    if (card != Reduction.none) {
+      final parts = card.vendoKey.split(' ');
+      ermaessigungen.add({
+        'art': parts[0],
+        'klasse': parts.length > 1 ? parts[1] : 'KLASSENLOS',
+      });
+    } else {
+      ermaessigungen.add({
+        'art': 'KEINE_ERMAESSIGUNG',
+        'klasse': 'KLASSENLOS',
+      });
+    }
+
+    // Weitere Ermäßigungen (foreign railcards: Halbtax, Vorteilscard, NL-40, …)
+    if (weitere != Reduction.none) {
+      final parts = weitere.vendoKey.split(' ');
+      ermaessigungen.add({
+        'art': parts[0],
+        'klasse': parts.length > 1 ? parts[1] : 'KLASSENLOS',
+      });
+    }
+
+    // Schwerbehindertenausweis
+    if (sba != SbaOption.none) {
+      final parts = sba.vendoKey.split(' ');
+      ermaessigungen.add({
+        'art': parts[0],
+        'klasse': parts.length > 1 ? parts[1] : 'KLASSENLOS',
+      });
+    }
+
     return [
       {
         'typ': 'ERWACHSENER',
-        'ermaessigungen': [
-          {
-            'art': bahnCard.apiValue,
-            'klasse': bahnCard.classValue,
-          }
-        ],
+        'ermaessigungen': ermaessigungen,
         'alter': [],
         'anzahl': 1,
       }
@@ -253,7 +293,9 @@ class DbApiService {
     final trimmed = input.trim();
     if (trimmed.isEmpty) return null;
     final url = _urlRe.firstMatch(trimmed)?.group(0) ?? trimmed;
-    final travellers = createTravellerPayload(bahnCard: bahnCard);
+    final travellers = createTravellerPayload(
+      bahnCard: Reduction.byKey(bahnCard.vendoErmaessigung),
+    );
 
     Map<String, dynamic>? data;
     final vbid = _extractVbid(url) ?? _extractVbid(trimmed);


### PR DESCRIPTION
…tive assumptions edit
## Problem
When split-ticket analysis used the DB API fallback (Vendo unavailable),
only the BahnCard was forwarded — `weitere` reductions (Halbtax, Vorteilscard,
NL-40 etc.) and SBA were silently dropped. Additionally, the segment pricing
class was read from the global BahnCard setting instead of the search party,
causing wrong pricing or no splits found.

## Changes
- **db_api_service.dart**: `createTravellerPayload` now accepts `weitere`
  (Reduction) and `sba` (SbaOption) so the fallback payload matches Vendo.
- **split_ticket_provider.dart**: Derives BahnCard, weitere, sba from
  `primaryTraveler`; fixes `firstClass` to use `searchParty.firstClass`.
- **bulk_split_provider.dart**: Same fix for the bulk comparison path.
- **settings_provider.dart**: `setBahnCard` syncs travelers in-place without
  wiping Halbtax/SBA; new `setWeitereReduction()` for global default.
- **settings_screen.dart**: Added "Weitere Ermäßigung" dropdown under Profil.
- **split_ticket_screen.dart**: "Preise gelten für" card now has an "Ändern"
  button that opens the traveler sheet and immediately re-runs the analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting an additional (“Weitere”) discount in profile settings.
  * Split-ticket assumptions now show all applicable discounts and Deutschland-Ticket status.
  * Added an option to edit the traveller party directly and rerun the analysis.

* **Bug Fixes**
  * Traveller discounts and first-class preferences now consistently match the selected search party.
  * Improved fallback handling when traveller information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->