### PR TITLE
feat(live): Live-Chip umschaltbar (Zeit/Stationen) + Zustands-Icon (#76)

### DIFF
--- a/flutter-app/android/app/src/main/res/drawable/ic_stat_train_alert.xml
+++ b/flutter-app/android/app/src/main/res/drawable/ic_stat_train_alert.xml
@@ -1,0 +1,17 @@
+<!-- Train glyph with a warning dot, for the Live-Update status-bar/Now-Bar icon
+     when the trip is delayed or cancelled (#76). White on transparent; Android
+     tints notification small icons itself. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Train body (slightly shrunk to make room for the warning at bottom-right). -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M11,1c-3.5,0 -7,0.44 -7,3.5v8.3C4,14.5 5.35,16 7,16L5.75,17.3v0.4h10.5v-0.4L15,16c1.65,0 3,-1.5 3,-3.2V4.5C18,1.44 14.5,1 11,1zM7,14.2c-0.73,0 -1.3,-0.58 -1.3,-1.3S6.27,11.6 7,11.6 8.3,12.18 8.3,12.9 7.73,14.2 7,14.2zM10.2,8.6L5.3,8.6L5.3,5.2h4.9v3.4zM11.8,8.6L11.8,5.2h4.9v3.4h-4.9z" />
+    <!-- Warning triangle, bottom-right. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,13l4,7h-8z" />
+</vector>

--- a/flutter-app/lib/providers/live_trip_provider.dart
+++ b/flutter-app/lib/providers/live_trip_provider.dart
@@ -197,6 +197,8 @@ class LiveTripTracker extends Notifier<LiveTripState>
       // it is the thing the rider actually looks at while travelling. Where the
       // device won't promote it this is a no-op and the alerts above stay the
       // only channel.
+      LiveUpdateService.chipShowsStops =
+          ref.read(settingsProvider).liveChipStops;
       unawaited(LiveUpdateService.show(journey.journey));
     } catch (e) {
       AppLog.log('live poll failed ($e)', tag: 'live');

--- a/flutter-app/lib/providers/settings_provider.dart
+++ b/flutter-app/lib/providers/settings_provider.dart
@@ -65,6 +65,10 @@ class AppSettings {
   /// default — the original wording stays unless the rider asks for simpler.
   final bool plainLanguage;
 
+  /// The live status-bar / Now-Bar chip shows the number of stops to the exit
+  /// instead of the minutes (#76). Off by default → minutes.
+  final bool liveChipStops;
+
   const AppSettings({
     this.bahnCard = BahnCardType.none,
     this.hasDeutschlandTicket = false,
@@ -82,6 +86,7 @@ class AppSettings {
     this.searchParty = const SearchParty(),
     this.partyCustomized = false,
     this.plainLanguage = false,
+    this.liveChipStops = false,
   });
 
   AppSettings copyWith({
@@ -101,6 +106,7 @@ class AppSettings {
     SearchParty? searchParty,
     bool? partyCustomized,
     bool? plainLanguage,
+    bool? liveChipStops,
   }) {
     return AppSettings(
       bahnCard: bahnCard ?? this.bahnCard,
@@ -119,6 +125,7 @@ class AppSettings {
       searchParty: searchParty ?? this.searchParty,
       partyCustomized: partyCustomized ?? this.partyCustomized,
       plainLanguage: plainLanguage ?? this.plainLanguage,
+      liveChipStops: liveChipStops ?? this.liveChipStops,
     );
   }
 }
@@ -155,6 +162,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
           SearchParty.fromSettings(bahnCard, dTicket),
       partyCustomized: prefs.getBool('partyCustomized') ?? false,
       plainLanguage: prefs.getBool('plainLanguage') ?? false,
+      liveChipStops: prefs.getBool('liveChipStops') ?? false,
     );
   }
 
@@ -176,10 +184,16 @@ class SettingsNotifier extends Notifier<AppSettings> {
     await prefs.setString('searchParty', state.searchParty.encode());
     await prefs.setBool('partyCustomized', state.partyCustomized);
     await prefs.setBool('plainLanguage', state.plainLanguage);
+    await prefs.setBool('liveChipStops', state.liveChipStops);
   }
 
   void setPlainLanguage(bool value) {
     state = state.copyWith(plainLanguage: value);
+    _save();
+  }
+
+  void setLiveChipStops(bool value) {
+    state = state.copyWith(liveChipStops: value);
     _save();
   }
 

--- a/flutter-app/lib/screens/settings/settings_screen.dart
+++ b/flutter-app/lib/screens/settings/settings_screen.dart
@@ -185,6 +185,16 @@ class SettingsScreen extends ConsumerWidget {
                   },
                 ),
                 const Divider(height: 1),
+                SwitchListTile(
+                  secondary: const Icon(Icons.tag),
+                  title: const Text('Live-Chip: Stationen statt Zeit'),
+                  subtitle: const Text(
+                      'Der kleine Status-Indikator (auch Samsung Now Bar) zeigt '
+                      'die Anzahl Halte bis zum Ausstieg statt der Restzeit.'),
+                  value: settings.liveChipStops,
+                  onChanged: (v) => notifier.setLiveChipStops(v),
+                ),
+                const Divider(height: 1),
                 ListTile(
                   leading: const Icon(Icons.directions_walk),
                   title: const Text('Umsteigeprofil'),

--- a/flutter-app/lib/services/live_update_service.dart
+++ b/flutter-app/lib/services/live_update_service.dart
@@ -35,6 +35,10 @@ class LiveUpdateService {
   /// Android 17 there is only the bar and this changes nothing.
   static LiveUpdateStyle preferredStyle = LiveUpdateStyle.auto;
 
+  /// Chip content: false = minutes to the exit, true = stops to the exit (#76).
+  /// Set from settings by the live tracker before each [show].
+  static bool chipShowsStops = false;
+
   static Future<bool> isSupported() async {
     if (_supported != null) return _supported!;
     final s = await LiveUpdate.isSupported();
@@ -106,8 +110,12 @@ class LiveUpdateService {
     try {
       final result = await LiveUpdate.post(
         title: title,
-        // A train glyph, not the app logo, for the running trip (#76).
-        smallIcon: 'ic_stat_train',
+        // A train glyph, not the app logo — and a train-with-warning when the
+        // trip is late or cancelled, so the status-bar icon itself carries the
+        // state (#76).
+        smallIcon: (trip.cancelled || trip.delayMinutes > 0)
+            ? 'ic_stat_train_alert'
+            : 'ic_stat_train',
         // Under the bar: the live pulse — the next stop with a countdown, which
         // is what tells the rider the train is moving and how far the next stop
         // is.
@@ -265,10 +273,31 @@ class LiveUpdateService {
   static String? _chip(LiveTripSummary trip, DateTime now) {
     if (trip.cancelled) return 'X';
     if (trip.delayMinutes > 0) return '+${trip.delayMinutes}';
+    if (chipShowsStops) {
+      final n = _stopsToExit(trip, now);
+      return (n != null && n > 0) ? '$n Hlt' : null;
+    }
     final at = _myStopArrival(trip);
     if (at == null) return null;
     final mins = at.difference(now).inMinutes;
     return (mins >= 0 && mins < 1000) ? "$mins'" : null;
+  }
+
+  /// Stops still ahead on the current leg, up to and including the exit — the
+  /// "wie viele Stationen noch" a rider can also choose for the chip (#76).
+  static int? _stopsToExit(LiveTripSummary trip, DateTime now) {
+    final leg = trip.currentLeg;
+    if (leg == null) return null;
+    var n = 0;
+    for (final s in leg.stopovers) {
+      final at = s.arrival ?? s.departure;
+      if (at != null && at.isAfter(now)) n++;
+    }
+    // Some legs carry no stopover list; fall back to "1 to go" while the leg is
+    // still ahead of its arrival.
+    final arr = _myStopArrival(trip);
+    if (n == 0 && arr != null && arr.isAfter(now)) n = 1;
+    return n;
   }
 
   /// Now Bar primary line — the one glance that matters: where the rider gets

--- a/flutter-app/test/live_update_service_test.dart
+++ b/flutter-app/test/live_update_service_test.dart
@@ -192,6 +192,22 @@ void main() {
     expect(calls.map((c) => c.method), isNot(contains('post')));
   });
 
+  test('chip can show stops-to-exit instead of minutes (#76)', () async {
+    LiveUpdateService.chipShowsStops = true;
+    addTearDown(() => LiveUpdateService.chipShowsStops = false);
+    await LiveUpdateService.show(_journey(), now: _at(9, 10));
+    // No stopover list on this leg → falls back to "1 to go" while en route.
+    expect(lastPost()['chipText'], '1 Hlt');
+  });
+
+  test('the icon carries the state: train, or train-alert when late (#76)',
+      () async {
+    await LiveUpdateService.show(_journey(), now: _at(9, 10));
+    expect(lastPost()['smallIcon'], 'ic_stat_train');
+    await LiveUpdateService.show(_journey(delay: 12), now: _at(9, 10));
+    expect(lastPost()['smallIcon'], 'ic_stat_train_alert');
+  });
+
   test('a dismissed Live Update does not come back', () async {
     await LiveUpdateService.show(_journey(), now: _at(9, 10));
     LiveUpdateService.markDismissed();


### PR DESCRIPTION
Folgt auf die Now-Bar-Rückmeldung in #76 (UnityHamster).

Android/Samsung geben Dritt-Apps für die Now Bar nur zwei zuverlässige Stellschrauben — den **Kurz-Indikator** (`shortCriticalText`) und das **kleine Icon**. Genau die werden hier nutzbar/dynamisch gemacht:

### Chip umschaltbar: Zeit ⟷ Stationen
- Neue Einstellung **„Live-Chip: Stationen statt Zeit"**.
- Aus (Default): Restzeit bis zum eigenen Ausstieg (`23'`).
- An: Anzahl Halte bis zum Ausstieg (`3 Hlt`).
- Verspätung/Ausfall haben weiter Vorrang (`+12` / `X`).

### Zustands-Icon statt statischem App-Logo
- Laufende Reise: **Zug-Icon** (`ic_stat_train`).
- Verspätet/ausgefallen: **Zug-mit-Warnung** (`ic_stat_train_alert`).

### Tests
- `live_update_service_test`: Chip-Modus (Stationen) + Zustands-Icon.
- Alle 792 Flutter-Tests grün, `flutter analyze` sauber (nur vorbestehende Radio-Deprecation-Infos).

Kein Release-Build in diesem PR — nur Code.

https://claude.ai/code/session_011PNix3zmjQx3DTiX6E1PjE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to display remaining stops instead of travel time in live trip notifications.
  * Added train alert icons for delayed or cancelled trips.
  * Live notifications now show the correct number of stops remaining, with a fallback when stop data is unavailable.

* **Bug Fixes**
  * Improved live trip notification status indicators for delayed and cancelled journeys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->