### PR TITLE
chore(vendo): remove redundant debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Besser Bahn
 
+[![Flutter CI](https://github.com/YousefAbaas/Besser-Bahn/actions/workflows/flutter-ci.yml/badge.svg)](https://github.com/YousefAbaas/Besser-Bahn/actions/workflows/flutter-ci.yml)
+
 **Privacy-first railway companion for Germany, built with Flutter.**
 
 Besser Bahn is a privacy-focused mobile application for frequent railway travelers in Germany. It combines journey planning, live departure information, real-time disruption data, maps, connection reliability, split-ticket analysis, and optional DB account integration in a single Flutter application.

--- a/README.md
+++ b/README.md
@@ -37,23 +37,80 @@ As a contributor to Besser Bahn, I worked on reliability, API integration, testi
 * Verified the migration with static analysis and the automated test suite.
 * Kept generated platform files and IDE artifacts out of the source changes.
 
-### DB / Vendo API Integration
+## DB Vendo API Investigation
 
-* Improved route and price parsing in the Vendo service.
-* Improved handling of DB upstream HTTP responses and actionable error messages.
-* Ensured request bodies are sent in the format expected by the upstream DB endpoint.
-* Added graceful handling for route-calculation failures so map functionality can continue when an upstream route request fails.
-* Improved parsing of journey, price, walking-route, and best-price response data.
+A significant part of the Besser Bahn work involved integrating and validating
+the DB Navigator mobile backend (Vendo) using real production responses.
 
-### Testing & CI
+Rather than relying exclusively on mocked fixtures, the integration was
+validated with dedicated live probes to verify undocumented response structures
+before mapping them into the application's domain models.
 
-* Added a GitHub Actions workflow for automated Flutter analysis and tests.
-* CI runs for relevant Flutter application changes on `main`, `chore/**`, and pull requests.
-* Added and maintained tests covering journey search, rerouting, transfer information, walking routes, station search, address search, split-ticket data, and related services.
-* Verified the upgraded application with **850 automated tests passing** and clean Flutter analysis.
+### Validated Vendo capabilities
 
+* **Journey search:** validated real journey responses and extracted stable
+  `zuglaufId` values for individual train runs.
+* **Zuglauf details:** validated the `/mob/zuglauf/{zuglaufId}` endpoint against
+  real ICE and regional train runs.
+* **Track polylines:** verified that Vendo returns detailed route geometry via
+  `polylineGroup.polylineDesc[].coordinates`.
+* **Real train example:** ICE 953 from Köln Hbf to Berlin Hbf returned **1,274
+  polyline points**, from approximately Köln (50.943038, 6.959700) to Berlin
+  (52.525841, 13.368874).
+* **Regional train example:** S6 train 30691 from Köln Hbf to Köln Messe/Deutz
+  returned **287 polyline points**.
+* **Stop data:** validated real stop-level data including stations, planned
+  platforms, realtime platforms, occupancy information, and arrival/departure
+  timestamps.
+* **Schedule metadata:** verified that `fahrplan.regulaererFahrplan` is not
+  guaranteed to be a structured object; for some real trains DB returns a
+  string such as `nicht täglich`. The parser therefore handles the upstream
+  type defensively.
+* **Occupancy data:** verified that `auslastungsInfos` can contain separate
+  first- and second-class entries with DB-provided availability text.
+* **Best-price endpoint:** validated daily price intervals, DB's
+  `istBestpreis` flag, connection contexts, price-less intervals, and
+  part-trip prices.
+
+### Validation approach
+
+The live investigation was performed with isolated Flutter test probes rather
+than changing production behavior blindly.
+
+The probes were used to:
+
+1. obtain real journey responses from the Vendo backend;
+2. extract real `zuglaufId` values;
+3. request individual train runs through the Vendo `zuglauf` endpoint;
+4. inspect the actual response structure and runtime types;
+5. validate parsing against both long-distance and regional trains;
+6. verify the returned polyline geometry and stop metadata;
+7. convert the discovered behavior into deterministic automated tests.
+
+This approach helped distinguish documented assumptions from behavior actually
+observed in the upstream production API.
+
+### Real-world Zuglauf validation
+
+Live Zuglauf responses were successfully retrieved and parsed for real
+connections including:
+
+**ICE 953 — Köln Hbf → Berlin Hbf**
+
+- 8 stops
+- Real `zuglaufId`
+- Platform information
+- Occupancy information for both classes
+- Service-day metadata
+- 1,274 route-polyline points
+
+The route geometry was parsed from Vendo's response structure:
+
+```text
+polylineGroup
+└── polylineDesc
+    └── coordinates
 ### Engineering Practices
-
 * Used focused commits describing individual engineering changes.
 * Kept generated platform files and IDE-specific files out of feature commits.
 * Used `git diff --check` and staged-diff inspection before committing.

--- a/README.md
+++ b/README.md
@@ -19,23 +19,105 @@ The application is designed to work without tracking, advertising, or a mandator
 | Mobile           | Flutter / Dart                                        |
 | State management | Riverpod                                              |
 | Navigation       | GoRouter                                              |
-| Networking       | REST/HTTP integrations                                |
+| Networking       | REST / HTTP integrations                              |
 | Maps             | OpenStreetMap-based mapping                           |
 | Local data       | Local persistence and offline caching                 |
-| Testing          | Flutter unit/widget tests                             |
+| Testing          | Flutter unit and widget tests                         |
 | CI               | GitHub Actions                                        |
-| Architecture     | Service / provider / model based Flutter architecture |
+| Architecture     | Service / provider / model-based Flutter architecture |
+
+## Quality Status
+
+The current codebase has been validated as a clean quality milestone.
+
+| Check             | Result             |
+| ----------------- | ------------------ |
+| `flutter analyze` | ✅ No issues found  |
+| `flutter test`    | ✅ 857 tests passed |
+| Quality release   | `v0.1.0-quality`   |
+
+The `v0.1.0-quality` release provides a stable baseline for continued development.
+
+## Features
+
+### 🔎 Journey Search
+
+* Connection search between two stations with station autocomplete.
+* Supports **coordinates and map links** as origins or destinations (`53.43, 14.53`, `geo:`, OpenStreetMap, Organic Maps, and Google Maps links) with nearby station resolution.
+* Detailed multi-leg connections including transfers, platforms, stops, and real-time delays.
+* **Connection and punctuality badges** for transfers, calculated using a self-hosted prediction model.
+* Sorting by **reliability**, rather than only by duration.
+* Highlights for **fastest, cheapest, and most reliable** connections.
+
+### 🔔 Live Journey Monitoring
+
+Per-journey monitoring can be enabled or disabled from the connection view.
+
+When enabled, the application can notify the user about:
+
+* Significant delay changes.
+* Platform changes at the user's station.
+* Train cancellations.
+* At-risk connections.
+* Arrival reminders.
+* Optional GPS-based exit alerts.
+
+#### Connection Rescue
+
+When a transfer becomes unlikely, Besser Bahn can calculate the next reachable connection based on the live arrival of the incoming train.
+
+The app can then suggest switching to the next viable connection and show the resulting impact on the journey.
+
+The monitoring workflow runs locally on the device without a server that tracks the user's journey.
+
+### 🚉 Station
+
+A combined station area provides:
+
+* **Train** — detailed information for an individual service, including stops, platforms, and delays.
+* **Departures** — live departure board with map support.
+* **Map** — interactive station map with platforms, elevators, and points of interest.
+
+### 🧭 Maps & Live Data
+
+* Exact track polylines based on DB-provided route geometry.
+* German basemap using BKG TopPlus-Open.
+* Offline map-tile caching on the device.
+* **Coach sequence and available seats** with carriage and seat-map information where available.
+* **Split-train detection** to identify the train section passengers should board.
+* Current location and nearby stations using GPS.
+
+### 💶 Split-Ticket Analysis
+
+* Finds potentially cheaper ticket combinations for a selected connection.
+* Supports **BahnCard 25/50**, first/second class, and **Deutschlandticket** scenarios.
+* Provides direct booking links for individual ticket segments.
+* Sends a local notification when analysis is complete.
+
+### 👤 Optional DB Account
+
+The application can optionally connect to a user's DB account.
+
+The account integration supports:
+
+* **My Tickets** — booked tickets including barcode presentation for inspection.
+* **BahnCard** — card and inspection views with offline availability.
+* **BahnBonus** — points and status information.
+* **Saved journeys** — synchronization with journeys saved in the DB account.
+* OAuth2 with **PKCE**, without storing the user's DB password in the application.
+
+The DB account is completely optional; the rest of the application remains usable without an account.
 
 ## My Contributions
 
-As a contributor to Besser Bahn, I worked on reliability, API integration, testing, and the Flutter toolchain.
+As a contributor to Besser Bahn, I worked on reliability, API integration, testing, Flutter tooling, and journey-search infrastructure.
 
-### Flutter 3.44.3 Upgrade
+### Flutter Upgrade
 
 * Upgraded the application to **Flutter 3.44.3**.
 * Stabilized affected application and test code across the Flutter upgrade.
 * Verified the migration with static analysis and the automated test suite.
-* Kept generated platform files and IDE artifacts out of the source changes.
+* Kept generated platform files and IDE artifacts out of feature changes.
 
 ### DB / Vendo API Integration
 
@@ -45,232 +127,84 @@ As a contributor to Besser Bahn, I worked on reliability, API integration, testi
 * Added graceful handling for route-calculation failures so map functionality can continue when an upstream route request fails.
 * Improved parsing of journey, price, walking-route, and best-price response data.
 
+### Journey Search & Offline Caching
+
+* Improved Riverpod-based journey-search state and provider integration.
+* Added offline caching for journey search results.
+* Added JSON serialization and deserialization for cached journey results.
+* Improved arrival-time searches, transport filters, transfer constraints, and journey sorting.
+* Added progressive loading of earlier and later connections.
+* Added fallback handling for relaxed transfer constraints when the initial search produces no connections.
+
 ### Testing & CI
 
 * Added a GitHub Actions workflow for automated Flutter analysis and tests.
 * CI runs for relevant Flutter application changes on `main`, `chore/**`, and pull requests.
 * Added and maintained tests covering journey search, rerouting, transfer information, walking routes, station search, address search, split-ticket data, and related services.
-* Verified the upgraded application with **850 automated tests passing** and clean Flutter analysis.
+* Verified the current codebase with **857 automated tests passing** and clean Flutter analysis.
 
 ### Engineering Practices
 
 * Used focused commits describing individual engineering changes.
 * Kept generated platform files and IDE-specific files out of feature commits.
 * Used `git diff --check` and staged-diff inspection before committing.
-* Merged the validated Flutter upgrade into `main` only after the working tree was clean.
+* Validated changes with static analysis and automated tests before pushing to `main`.
+* Maintained a tagged quality milestone with `v0.1.0-quality`.
 
-> This repository is also useful as a practical example of working with an existing Flutter codebase: understanding unfamiliar services, modifying API integrations, maintaining tests, upgrading dependencies, and validating changes through CI.
-
-
-
-
-## Funktionen
-
-### 🔎 Suche
-- Verbindungssuche zwischen zwei Stationen mit Stationsautovervollständigung
-- Auch **Koordinaten oder Kartenlinks** als Start/Ziel (`53.43, 14.53`, `geo:`,
-  OpenStreetMap-, Organic-Maps-, Google-Maps-Links) → Haltestellen in der Nähe
-- Mehrteilige Verbindungsdetails: alle Umstiege, Gleise, Halte und Echtzeit-Verspätungen
-- **Anschluss- und Pünktlichkeits-Badges** je Umstieg, berechnet von einem
-  selbst gehosteten Vorhersage-Modell
-- Sortierung nach **Zuverlässigkeit** — nicht nur nach Dauer, sondern danach,
-  wie wahrscheinlich die Reise wirklich aufgeht
-- **⚡ Schnellste · 💶 Günstigste · 🛡️ Sicherste · ⭐ Bester Kompromiss** werden
-  in der Trefferliste markiert (nur wenn sie sich wirklich unterscheiden)
-
-### 🔔 Live-Reisebegleitung
-Pro Reise ein-/ausschaltbar („Reise überwachen" in der Verbindungsansicht),
-App im Vordergrund, Erinnerungen aktiviert:
-- Push bei **Verspätungssprung, Gleiswechsel am eigenen Halt, Zugausfall** und
-  **gefährdetem Anschluss**
-- **Anschlussrettung**: Bei knappem Umstieg erscheint automatisch der nächste
-  *erreichbare* Zug (gerechnet ab der Live-Ankunft des einfahrenden Zuges) samt
-  „Wechseln" auf einen Tipp — inklusive der Folge, falls der Anschluss platzt
-  („1:05 Std später am Ziel")
-- **Ankunfts-Wecker** und optionaler GPS-Ausstiegsalarm
-- **Umsteigeprofil** (Schnell · Normal · Gepäck · Kind · Fahrrad · Barrierearm ·
-  Mehr Zeit): „8 Minuten Umstieg" wird nicht für alle gleich bewertet — ändert
-  nur die Warnschwelle, nicht die Fahrplanzeiten. Bleibt auf dem Gerät.
-- **Umleitung / geänderter Zuglauf** wird als solche gekennzeichnet, inklusive
-  Zusatzhalten und entfallenen Halten
-- Läuft ausschließlich auf dem Gerät: kein Server, der die Reise mitliest
-
-### 🚉 Bahnhof
-Ein kombinierter Tab mit interner Umschaltung zwischen:
-- **Zug** – Zuglauf einer einzelnen Fahrt mit allen Halten, Gleisen und Verspätungen
-- **Abfahrten** – Live-Abfahrtstafel eines Bahnhofs, inklusive Kartenansicht
-- **Karte** – interaktive Bahnhofskarte (Bahnsteige, Aufzüge, POIs)
-
-### 🧭 Karten & Live-Daten
-- Streckenverlauf als exakte Gleis-Polylinie, die die DB selbst zeichnet
-- Neutraler deutscher Basemap-Hintergrund (BKG TopPlus-Open, grau)
-- Offline-Kachel-Cache auf dem Gerät
-- **Wagenreihung & freie Sitzplätze** – Sitzplatzkarte und Wagenreihenfolge je Zug
-- **Flügelzug-Erkennung** – zeigt an, in welchen Zugteil man einsteigen muss
-- „Mein Standort" und Stationen in der Nähe per GPS
-
-### 💶 Split-Ticket
-- Findet günstigere Ticket-Kombinationen für eine gefundene Verbindung
-- Berücksichtigt **BahnCard** (25/50, 1./2. Klasse) und **Deutschland-Ticket**
-- Direkte Buchungslinks für jedes Teil-Ticket (oberstes Angebot = das richtige)
-- OS-Benachrichtigung, sobald die Analyse fertig ist
-
-### 👤 DB-Konto (optional)
-Das eigene DB-Konto lässt sich verbinden — die App spricht dann dasselbe
-Backend wie der DB Navigator:
-- **Meine Tickets** – gebuchte Fahrkarten inklusive **Barcode zum Vorzeigen**
-  bei der Kontrolle
-- **BahnCard** – Kartenansicht und Kontrollansicht, offline verfügbar
-- **BahnBonus** – Punkte- und Statusstand
-- **Gemerkte Reisen** synchronisieren mit „Meine Reisen" im DB-Konto
-- Login per OAuth2 (PKCE, kein Passwort in der App); komplett optional — ohne
-  Konto funktioniert alles andere unverändert
-
-### 🤝 Träwelling
-- Login per OAuth2 (PKCE, kein Passwort in der App)
-- Per-Bein-Check-in direkt aus der Verbindungsansicht
-- Auto-Check-in: ein Tipp auf das Träwelling-Symbol im Zug checkt ein
-- Feed & Freunde, einstellbare Standard-Sichtbarkeit
-
-### 📚 Reisen
-- Lokale Bibliothek: Favoriten, zuletzt gesucht, gespeicherte Routen und Züge
-- Häufige Suchen werden automatisch als Favorit markiert
-
-### 🔗 Teilen
-- Offizielles „Reise teilen": erzeugt einen echten DB-Buchungslink für genau
-  diese Verbindung (nicht nur eine Suche)
-
-## Datenschutz
-
-- **Kein Tracking, kein Firebase, kein Google Analytics, keine Werbung**
-- Suchanfragen, Favoriten und Tokens bleiben auf dem Gerät
-- Das Vorhersage-Backend läuft auf Servern in Deutschland (Hetzner, DSGVO-konform)
-- Siehe [PRIVACY-POLICY.md](PRIVACY-POLICY.md)
-
-## Installation
-
-### Android
-Gehe zur [Releases-Seite](https://github.com/chukfinley/Besser-Bahn/releases)
-und lade die neueste Version herunter.
-
-### iOS
-Ich besitze weder einen Mac noch ein iOS-Gerät, um die App für iOS zu
-kompilieren. Wenn du die App erfolgreich für iOS bauen kannst, melde dich gerne —
-ich stelle die iOS-Version dann offiziell hier bereit.
-
-## Fehler melden
-
-[Neues Issue anlegen](https://github.com/chukfinley/Besser-Bahn/issues/new/choose)
-— es gibt zwei Formulare (Fehler / Idee), beide fragen **App-Version** und
-**Installationsquelle** ab. Beides ist Pflicht, und zwar aus einem praktischen
-Grund: die Version steht in der App unter **Einstellungen → ganz oben**, und die
-Quelle entscheidet, wie alt dein Stand ist (IzzyOnDroid liegt oft ein paar Tage
-hinter einem GitHub-Release). Mit beidem lässt sich in Sekunden sehen, ob der
-Fehler längst behoben ist — ohne beginnt jede Meldung mit einer Rückfrage.
-
-Hilft zusätzlich sehr: **Einstellungen → Debug-Log → Teilen** (enthält die
-Live-API-Aufrufe; Tokens werden nicht geloggt).
-
-## Wie es funktioniert
-
-Die App nutzt **keine offizielle Endkunden-API** der Deutschen Bahn. Stattdessen
-spricht sie bevorzugt das Backend der **DB-Navigator-App** an
-(`app.services-bahn.de/mob`), das die echten Fahrplan-, Preis-, Wagenreihungs-
-und Streckendaten liefert. Als Rückfallebene dienen die bahn.de-Web-API und ein
-öffentlicher HAFAS-Spiegel.
-
-Die **Anschluss- und Pünktlichkeits-Vorhersage** kommt von einem separaten,
-selbst gehosteten Dienst (`bahn.chuk.dev`), der ein Verspätungsmodell bereitstellt.
-
-Die Split-Ticket-Logik zerlegt eine Verbindung in alle möglichen Teilstrecken
-und findet per dynamischer Programmierung die günstigste Kombination, die die
-gesamte Strecke abdeckt — inklusive BahnCard- und Deutschland-Ticket-Rabatten.
-
-## Projektstruktur
-
-| Verzeichnis          | Inhalt                                                        |
-| -------------------- | ------------------------------------------------------------- |
-| `flutter-app/`       | Die App (Flutter, Riverpod, GoRouter)                         |
-| `prediction-service/`| Selbst gehostete Verspätungs-/Anschluss-Vorhersage-API        |
-| `api-tests/`         | Health-Checks für alle genutzten Upstream-Endpunkte           |
-| `docs/`              | Projekt-Webseite                                              |
-| `main.py`            | Split-Ticket-Logik auch als eigenständiges Python-CLI         |
+> This repository demonstrates practical work on an existing Flutter codebase: understanding unfamiliar services, modifying API integrations, maintaining tests, upgrading dependencies, implementing offline caching, and validating changes through CI.
 
 ## Development
 
-### App bauen
+### Prerequisites
+
+* Flutter SDK
+* Dart SDK
+* Android Studio or another Flutter-compatible IDE
+
+### Run locally
 
 ```bash
-git clone https://github.com/chukfinley/Besser-Bahn
-cd Besser-Bahn/flutter-app
 flutter pub get
 flutter run
 ```
 
-Voraussetzung: Flutter (SDK ^3.10) auf dem System installiert.
-
-### Endpunkt-Health-Check
-
-Vor Arbeiten an Netzwerk-/Datencode prüft `api-tests/healthcheck.py`, ob alle
-Upstream-Endpunkte noch die erwartete Antwortform liefern:
+### Verify the project
 
 ```bash
-cd api-tests && python3 healthcheck.py
+flutter analyze
+flutter test
 ```
 
-### Split-Ticket als CLI
+## CI
 
-Die Split-Ticket-Analyse läuft auch ohne App:
+The project uses GitHub Actions to automatically validate Flutter changes.
 
-```bash
-uv run main.py "https://www.bahn.de/buchung/start?vbid=..." [--age 30] [--bahncard BC25_2] [--deutschland-ticket]
-```
+The CI workflow runs static analysis and the automated test suite for relevant branches and pull requests.
 
-## Empfohlene Open-Source Bahn-Projekte und Tools
+## Quality Release
 
-*   **Traewelldroid** – Check-in-App für ÖPNV/Fernverkehr in Europa, basiert auf
-    Open-Data-Schnittstellen.
-    [Codeberg](https://codeberg.org/traewelldroid/traewelldroid)
-*   **Transportr** – quelloffene ÖPNV-App für viele Regionen weltweit.
-    [GitHub](https://github.com/grote/Transportr)
-*   **OpenRailwayMap** – detaillierte interaktive Karte des weltweiten
-    Eisenbahnnetzes auf OSM-Basis. [Website](https://openrailwaymap.org/)
-*   **bahn.expert** – tiefe Analyse von Zugverbindungen, Verspätungen und
-    Pünktlichkeitsstatistiken. [Website](https://bahn.expert/)
+### `v0.1.0-quality`
 
-## Datenschutz im Bahnverkehr
+This release represents a verified quality milestone for the project.
 
-Organisationen wie Digitalcourage setzen sich für Transparenz und Nutzerrechte ein:
+Highlights:
 
-*   **Klage gegen die Deutsche Bahn wegen Datenerfassung im DB Navigator** –
-    Digitalcourage hat die DB verklagt, weil der „DB Navigator" persönliche Daten
-    ohne ausreichende Einwilligung weitergibt.
-    [Details bei Digitalcourage](https://digitalcourage.de/pressemitteilungen/2025/bahn-klage-termin)
+* Clean Flutter analyzer result.
+* 857 automated tests passing.
+* Improved journey-search provider integration.
+* Offline journey-result caching.
+* Journey-result JSON serialization.
+* Improved DB / Vendo API handling.
+* Improved Riverpod provider integration.
 
-## Spenden
+## Roadmap
 
-Wenn diese App dir hilft, bei deinen Bahnreisen Geld zu sparen, freue ich mich
-über eine Spende — sie sichert Weiterentwicklung und Wartung. Die
-Spendenmöglichkeiten findest du über den „Sponsor"-Button oben auf dieser
-GitHub-Seite.
+* Continue improving journey reliability prediction.
+* Expand offline capabilities.
+* Improve live disruption and connection-rescue workflows.
+* Continue strengthening automated test coverage.
+* Improve platform-specific UX and accessibility.
 
-## Beitragen
+## License
 
-Beiträge sind willkommen! Öffne ein Issue oder einen Pull Request, wenn du
-Verbesserungen vorschlagen möchtest.
-
-## Lizenz
-
-Lizenziert unter der DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE — siehe
-[LICENSE.txt](LICENSE.txt).
-
-## Haftungsausschluss
-
-Diese App ist ein inoffizielles Projekt und steht in keiner Verbindung zur
-Deutschen Bahn AG. Die Nutzung erfolgt auf eigene Gefahr. Die gefundenen
-Split-Tickets entsprechen den Beförderungsbedingungen der Deutschen Bahn.
-
-## Danksagung
-
-Großer Dank an Lukas Weihrauch und sein Video, das die Inspiration für dieses
-Projekt lieferte: [https://youtu.be/SxKtI8f5QTU](https://youtu.be/SxKtI8f5QTU)
+See the repository license for the current licensing terms.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,66 @@
 # Besser Bahn
 
-**Die bessere Bahn-App. Privacy-first, für Vielfahrer.**
+**Privacy-first railway companion for Germany, built with Flutter.**
 
-Ein Premium-Begleiter für die Deutsche Bahn: Verbindungssuche, Live-Abfahrten,
-Zugläufe auf der Karte, Verspätungs- und Anschluss-Vorhersage, Träwelling-Check-ins
-und das Finden günstigerer Split-Tickets — alles ohne Tracking, ohne Werbung,
-ohne Konto-Zwang.
+Besser Bahn is a privacy-focused mobile application for frequent railway travelers in Germany. It combines journey planning, live departure information, real-time disruption data, maps, connection reliability, split-ticket analysis, and optional DB account integration in a single Flutter application.
 
-Optional lässt sich das **eigene DB-Konto verbinden** — dann liegen **Tickets
-(inkl. Barcode zum Vorzeigen), BahnCard und BahnBonus** direkt in der App.
+The application is designed to work without tracking, advertising, or a mandatory account.
 
 <p align="center">
-  <img src="assets/app_icon.png" width="100" />
+  <img src="assets/app_icon.png" width="100" alt="Besser Bahn app icon" />
 </p>
+
+## Engineering Snapshot
+
+| Area             | Technology / Approach                                 |
+| ---------------- | ----------------------------------------------------- |
+| Mobile           | Flutter / Dart                                        |
+| State management | Riverpod                                              |
+| Navigation       | GoRouter                                              |
+| Networking       | REST/HTTP integrations                                |
+| Maps             | OpenStreetMap-based mapping                           |
+| Local data       | Local persistence and offline caching                 |
+| Testing          | Flutter unit/widget tests                             |
+| CI               | GitHub Actions                                        |
+| Architecture     | Service / provider / model based Flutter architecture |
+
+## My Contributions
+
+As a contributor to Besser Bahn, I worked on reliability, API integration, testing, and the Flutter toolchain.
+
+### Flutter 3.44.3 Upgrade
+
+* Upgraded the application to **Flutter 3.44.3**.
+* Stabilized affected application and test code across the Flutter upgrade.
+* Verified the migration with static analysis and the automated test suite.
+* Kept generated platform files and IDE artifacts out of the source changes.
+
+### DB / Vendo API Integration
+
+* Improved route and price parsing in the Vendo service.
+* Improved handling of DB upstream HTTP responses and actionable error messages.
+* Ensured request bodies are sent in the format expected by the upstream DB endpoint.
+* Added graceful handling for route-calculation failures so map functionality can continue when an upstream route request fails.
+* Improved parsing of journey, price, walking-route, and best-price response data.
+
+### Testing & CI
+
+* Added a GitHub Actions workflow for automated Flutter analysis and tests.
+* CI runs for relevant Flutter application changes on `main`, `chore/**`, and pull requests.
+* Added and maintained tests covering journey search, rerouting, transfer information, walking routes, station search, address search, split-ticket data, and related services.
+* Verified the upgraded application with **850 automated tests passing** and clean Flutter analysis.
+
+### Engineering Practices
+
+* Used focused commits describing individual engineering changes.
+* Kept generated platform files and IDE-specific files out of feature commits.
+* Used `git diff --check` and staged-diff inspection before committing.
+* Merged the validated Flutter upgrade into `main` only after the working tree was clean.
+
+> This repository is also useful as a practical example of working with an existing Flutter codebase: understanding unfamiliar services, modifying API integrations, maintaining tests, upgrading dependencies, and validating changes through CI.
+
+
+
 
 ## Funktionen
 

--- a/flutter-app/lib/core/cache/app_cache.dart
+++ b/flutter-app/lib/core/cache/app_cache.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AppCache {
+  static const _prefix = 'cache_';
+
+  static Future<void> save(String key, Map<String, dynamic> value) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(
+      '$_prefix$key',
+      jsonEncode({
+        'createdAt': DateTime.now().toIso8601String(),
+        'data': value,
+      }),
+    );
+  }
+
+  static Future<Map<String, dynamic>?> read(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final raw = prefs.getString('$_prefix$key');
+
+    if (raw == null) return null;
+
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+
+    return json;
+  }
+
+  static Future<void> remove(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.remove('$_prefix$key');
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix));
+
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+}

--- a/flutter-app/lib/core/cache/cache_entry.dart
+++ b/flutter-app/lib/core/cache/cache_entry.dart
@@ -1,0 +1,10 @@
+class CacheEntry<T> {
+  final T data;
+  final DateTime createdAt;
+
+  const CacheEntry({required this.data, required this.createdAt});
+
+  bool isExpired(Duration ttl) {
+    return DateTime.now().difference(createdAt) > ttl;
+  }
+}

--- a/flutter-app/lib/core/cache/cache_policy.dart
+++ b/flutter-app/lib/core/cache/cache_policy.dart
@@ -1,0 +1,9 @@
+class CachePolicy {
+  final Duration ttl;
+
+  const CachePolicy({required this.ttl});
+
+  static const journeySearch = CachePolicy(ttl: Duration(hours: 2));
+
+  static const stationSearch = CachePolicy(ttl: Duration(days: 7));
+}

--- a/flutter-app/lib/core/journey_cache.dart
+++ b/flutter-app/lib/core/journey_cache.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/journey.dart';
+
+class JourneyCache {
+  static String key({
+    required String from,
+    required String to,
+    required DateTime dateTime,
+    required bool arrival,
+  }) {
+    return '${from}_${to}_${dateTime.toIso8601String()}_$arrival';
+  }
+
+  static Future<void> write(String key, JourneyResult result) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(key, jsonEncode(result.toJson()));
+  }
+
+  static Future<JourneyResult?> read(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final raw = prefs.getString(key);
+
+    if (raw == null) return null;
+
+    try {
+      return JourneyResult.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+    } catch (_) {
+      await prefs.remove(key);
+      return null;
+    }
+  }
+}

--- a/flutter-app/lib/core/journey_reliability.dart
+++ b/flutter-app/lib/core/journey_reliability.dart
@@ -1,0 +1,112 @@
+import '../models/journey.dart';
+
+enum JourneyReliabilityLevel {
+  veryReliable,
+  reliable,
+  moderate,
+  risky,
+  veryRisky,
+}
+
+class JourneyReliability {
+  final int score;
+  final JourneyReliabilityLevel level;
+  final List<String> reasons;
+
+  const JourneyReliability({
+    required this.score,
+    required this.level,
+    required this.reasons,
+  });
+}
+
+class JourneyReliabilityAnalyzer {
+  const JourneyReliabilityAnalyzer._();
+
+  static JourneyReliability analyze(Journey journey) {
+    var score = 100;
+    final reasons = <String>[];
+
+    if (journey.hasCancelledLeg) {
+      score -= 60;
+      reasons.add('Cancelled train');
+    } else if (journey.hasPartialCancellation) {
+      score -= 30;
+      reasons.add('Partial cancellation');
+    }
+
+    final delays = journey.legs
+        .where((leg) => !leg.isWalking)
+        .expand<int>(
+          (leg) => [leg.departureDelayMinutes, leg.arrivalDelayMinutes],
+        );
+
+    final maxDelay = delays.fold<int>(0, (max, delay) {
+      return delay > max ? delay : max;
+    });
+
+    if (maxDelay > 10) {
+      score -= 15;
+      reasons.add('Significant delay');
+    } else if (maxDelay >= 5) {
+      score -= 8;
+      reasons.add('Delay');
+    }
+
+    if (journey.legs.any((leg) => leg.endsEarly)) {
+      score -= 35;
+      reasons.add('Train ends early');
+    }
+
+    if (journey.legs.any((leg) => leg.disruptions.isNotEmpty) ||
+        journey.disruptions.isNotEmpty) {
+      score -= 10;
+      reasons.add('Service disruption');
+    }
+
+    for (final leg in journey.legs) {
+      if (leg.hasDeparturePlatformChange || leg.hasArrivalPlatformChange) {
+        score -= 8;
+        reasons.add('Platform change');
+        break;
+      }
+    }
+
+    for (final leg in journey.legs) {
+      final buffer = leg.transferBufferMinutes;
+      if (buffer == null) continue;
+
+      if (buffer < 5) {
+        score -= 25;
+        reasons.add('Short transfer buffer');
+      } else if (buffer < 10) {
+        score -= 12;
+        reasons.add('Limited transfer buffer');
+      } else if (buffer >= 15) {
+        score += 3;
+      }
+    }
+
+    final transferCount = journey.transfers;
+    if (transferCount > 1) {
+      score -= (transferCount - 1) * 5;
+      reasons.add('Multiple transfers');
+    }
+
+    score = score.clamp(0, 100);
+
+    return JourneyReliability(
+      score: score,
+      level: _levelFor(score),
+      reasons: List.unmodifiable(reasons),
+    );
+  }
+
+  static JourneyReliabilityLevel _levelFor(int score) {
+    if (score >= 90) return JourneyReliabilityLevel.veryReliable;
+    if (score >= 75) return JourneyReliabilityLevel.reliable;
+    if (score >= 50) return JourneyReliabilityLevel.moderate;
+    if (score >= 25) return JourneyReliabilityLevel.risky;
+    return JourneyReliabilityLevel.veryRisky;
+  }
+}

--- a/flutter-app/lib/core/search_history_cache.dart
+++ b/flutter-app/lib/core/search_history_cache.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/journey_search.dart';
+
+class SearchHistoryCache {
+  static const _key = 'search_history';
+
+  Future<List<JourneySearch>> read() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final data = prefs.getString(_key);
+
+    if (data == null) {
+      return [];
+    }
+
+    final list = jsonDecode(data) as List<dynamic>;
+
+    return list
+        .whereType<Map<String, dynamic>>()
+        .map(JourneySearch.fromJson)
+        .toList();
+  }
+
+  Future<void> write(List<JourneySearch> searches) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(
+      _key,
+      jsonEncode(searches.map((e) => e.toJson()).toList()),
+    );
+  }
+
+  Future<void> add(JourneySearch search) async {
+    final current = await read();
+
+    current.removeWhere((e) => e.from == search.from && e.to == search.to);
+
+    current.insert(0, search);
+
+    if (current.length > 10) {
+      current.removeLast();
+    }
+
+    await write(current);
+  }
+}

--- a/flutter-app/lib/home/home_options_card.dart
+++ b/flutter-app/lib/home/home_options_card.dart
@@ -25,38 +25,25 @@ class HomeOptionsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(
-          12.0,
-        ),
+        padding: const EdgeInsets.all(12.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Text(
               'Reisende & Rabatte',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
-            const SizedBox(
-              height: 12,
-            ),
+            const SizedBox(height: 12),
             Row(
               children: [
-                const Text(
-                  'Alter:',
-                ),
-                const SizedBox(
-                  width: 8,
-                ),
+                const Text('Alter:'),
+                const SizedBox(width: 8),
                 SizedBox(
                   width: 60,
                   child: TextField(
                     controller: ageController,
                     keyboardType: TextInputType.number,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                    ],
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),
                       contentPadding: EdgeInsets.symmetric(
@@ -66,23 +53,15 @@ class HomeOptionsCard extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(
-                  width: 16,
-                ),
-                const Text(
-                  'Delay (ms):',
-                ),
-                const SizedBox(
-                  width: 8,
-                ),
+                const SizedBox(width: 16),
+                const Text('Delay (ms):'),
+                const SizedBox(width: 8),
                 SizedBox(
                   width: 80,
                   child: TextField(
                     controller: delayController,
                     keyboardType: TextInputType.number,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                    ],
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),
                       contentPadding: EdgeInsets.symmetric(
@@ -94,25 +73,17 @@ class HomeOptionsCard extends StatelessWidget {
                 ),
               ],
             ),
-            const SizedBox(
-              height: 12,
-            ),
+            const SizedBox(height: 12),
             CheckboxListTile(
-              title: const Text(
-                'Deutschland-Ticket',
-              ),
+              title: const Text('Deutschland-Ticket'),
               value: hasDeutschlandTicket,
               onChanged: onDeutschlandTicketChanged,
               controlAffinity: ListTileControlAffinity.leading,
               contentPadding: EdgeInsets.zero,
               dense: true,
             ),
-            const SizedBox(
-              height: 12,
-            ),
-            DropdownButtonFormField<
-              String?
-            >(
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String?>(
               decoration: const InputDecoration(
                 labelText: 'BahnCard',
                 border: OutlineInputBorder(),
@@ -121,17 +92,11 @@ class HomeOptionsCard extends StatelessWidget {
                   vertical: 12,
                 ),
               ),
-              value: selectedBahnCard,
-              items: bahnCardOptions.map((
-                option,
-              ) {
-                return DropdownMenuItem<
-                  String?
-                >(
+              initialValue: selectedBahnCard,
+              items: bahnCardOptions.map((option) {
+                return DropdownMenuItem<String?>(
                   value: option['value'],
-                  child: Text(
-                    option['label']!,
-                  ),
+                  child: Text(option['label']!),
                 );
               }).toList(),
               onChanged: onBahnCardChanged,

--- a/flutter-app/lib/models/journey.dart
+++ b/flutter-app/lib/models/journey.dart
@@ -6,17 +6,33 @@ class JourneyResult {
   final String? earlierRef;
   final String? laterRef;
 
-  const JourneyResult({
-    required this.journeys,
-    this.earlierRef,
-    this.laterRef,
-  });
+  const JourneyResult({required this.journeys, this.earlierRef, this.laterRef});
+
+  Map<String, dynamic> toJson() => {
+    'journeys': journeys.map((j) => j.toJson()).toList(),
+    'earlierRef': earlierRef,
+    'laterRef': laterRef,
+  };
+
+  factory JourneyResult.fromJson(Map<String, dynamic> json) {
+    return JourneyResult(
+      journeys: (json['journeys'] as List<dynamic>? ?? [])
+          .whereType<Map<String, dynamic>>()
+          .map(Journey.fromJson)
+          .toList(),
+      earlierRef: json['earlierRef'] as String?,
+      laterRef: json['laterRef'] as String?,
+    );
+  }
 
   factory JourneyResult.fromHafas(Map<String, dynamic> json) {
     final list = json['journeys'] as List<dynamic>? ?? [];
+
     return JourneyResult(
-      journeys:
-          list.whereType<Map<String, dynamic>>().map(Journey.fromHafas).toList(),
+      journeys: list
+          .whereType<Map<String, dynamic>>()
+          .map(Journey.fromHafas)
+          .toList(),
       earlierRef: json['earlierRef'] as String?,
       laterRef: json['laterRef'] as String?,
     );
@@ -83,27 +99,27 @@ class Journey {
   }
 
   Map<String, dynamic> toJson() => {
-        'legs': legs.map((l) => l.toJson()).toList(),
-        'refreshToken': refreshToken,
-        'price': price?.toJson(),
-        'disruptions': disruptions,
-        'serviceDaysNote': serviceDaysNote,
-      };
+    'legs': legs.map((l) => l.toJson()).toList(),
+    'refreshToken': refreshToken,
+    'price': price?.toJson(),
+    'disruptions': disruptions,
+    'serviceDaysNote': serviceDaysNote,
+  };
 
   factory Journey.fromJson(Map<String, dynamic> json) => Journey(
-        legs: (json['legs'] as List<dynamic>? ?? [])
-            .whereType<Map<String, dynamic>>()
-            .map(JourneyLeg.fromJson)
-            .toList(),
-        refreshToken: json['refreshToken'] as String?,
-        disruptions: (json['disruptions'] as List<dynamic>? ?? const [])
-            .whereType<String>()
-            .toList(),
-        serviceDaysNote: json['serviceDaysNote'] as String?,
-        price: json['price'] is Map<String, dynamic>
-            ? JourneyPrice.fromJson(json['price'] as Map<String, dynamic>)
-            : null,
-      );
+    legs: (json['legs'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .map(JourneyLeg.fromJson)
+        .toList(),
+    refreshToken: json['refreshToken'] as String?,
+    disruptions: (json['disruptions'] as List<dynamic>? ?? const [])
+        .whereType<String>()
+        .toList(),
+    serviceDaysNote: json['serviceDaysNote'] as String?,
+    price: json['price'] is Map<String, dynamic>
+        ? JourneyPrice.fromJson(json['price'] as Map<String, dynamic>)
+        : null,
+  );
 
   Station? get origin => legs.firstOrNull?.origin;
   Station? get destination => legs.lastOrNull?.destination;
@@ -130,9 +146,11 @@ class Journey {
     return '${minutes}min';
   }
 
-  bool get hasDelay => legs.any((l) =>
-      (l.departureDelay != null && l.departureDelay! > 0) ||
-      (l.arrivalDelay != null && l.arrivalDelay! > 0));
+  bool get hasDelay => legs.any(
+    (l) =>
+        (l.departureDelay != null && l.departureDelay! > 0) ||
+        (l.arrivalDelay != null && l.arrivalDelay! > 0),
+  );
 
   /// At least one transit leg of this connection is fully cancelled — the
   /// connection as planned cannot be travelled.
@@ -141,8 +159,7 @@ class Journey {
   /// A leg runs but drops one of its intermediate stops (Teilausfall), without
   /// the whole leg being cancelled.
   bool get hasPartialCancellation =>
-      !hasCancelledLeg &&
-      legs.any((l) => !l.isWalking && l.partiallyCancelled);
+      !hasCancelledLeg && legs.any((l) => !l.isWalking && l.partiallyCancelled);
 
   /// Whether the change into [leg] stays on one platform, as DB says
   /// (`weiterfahrtAmGleichenBahnsteig`, #20 point 6).
@@ -287,8 +304,7 @@ class JourneyLeg {
 
   int get departureDelayMinutes =>
       departureDelay != null ? departureDelay! ~/ 60 : 0;
-  int get arrivalDelayMinutes =>
-      arrivalDelay != null ? arrivalDelay! ~/ 60 : 0;
+  int get arrivalDelayMinutes => arrivalDelay != null ? arrivalDelay! ~/ 60 : 0;
 
   /// The leg runs but at least one of its intermediate stops is dropped
   /// ("Halt entfällt"), while the leg itself isn't fully cancelled.
@@ -332,79 +348,80 @@ class JourneyLeg {
   }
 
   Map<String, dynamic> toJson() => {
-        'tripId': tripId,
-        'origin': origin.toJson(),
-        'destination': destination.toJson(),
-        'departure': departure?.toIso8601String(),
-        'plannedDeparture': plannedDeparture?.toIso8601String(),
-        'departureDelay': departureDelay,
-        'departurePlatform': departurePlatform,
-        'plannedDeparturePlatform': plannedDeparturePlatform,
-        'arrival': arrival?.toIso8601String(),
-        'plannedArrival': plannedArrival?.toIso8601String(),
-        'arrivalDelay': arrivalDelay,
-        'arrivalPlatform': arrivalPlatform,
-        'plannedArrivalPlatform': plannedArrivalPlatform,
-        'line': line?.toJson(),
-        'direction': direction,
-        'walking': isWalking,
-        'distance': walkingDistance,
-        'walkingSeconds': walkingDuration?.inSeconds,
-        'transferAvailableSeconds': transferAvailable?.inSeconds,
-        'samePlatformTransfer': samePlatformTransfer,
-        'cancelled': cancelled,
-        'stopovers': stopovers.map((s) => s.toJson()).toList(),
-        'occupancy': occupancy?.level.name,
-        'disruptions': disruptions,
-        'replacementDestination': replacementDestination?.toJson(),
-        'replacementArrival': replacementArrival?.toIso8601String(),
-        'replacementArrivalPlatform': replacementArrivalPlatform,
-      };
+    'tripId': tripId,
+    'origin': origin.toJson(),
+    'destination': destination.toJson(),
+    'departure': departure?.toIso8601String(),
+    'plannedDeparture': plannedDeparture?.toIso8601String(),
+    'departureDelay': departureDelay,
+    'departurePlatform': departurePlatform,
+    'plannedDeparturePlatform': plannedDeparturePlatform,
+    'arrival': arrival?.toIso8601String(),
+    'plannedArrival': plannedArrival?.toIso8601String(),
+    'arrivalDelay': arrivalDelay,
+    'arrivalPlatform': arrivalPlatform,
+    'plannedArrivalPlatform': plannedArrivalPlatform,
+    'line': line?.toJson(),
+    'direction': direction,
+    'walking': isWalking,
+    'distance': walkingDistance,
+    'walkingSeconds': walkingDuration?.inSeconds,
+    'transferAvailableSeconds': transferAvailable?.inSeconds,
+    'samePlatformTransfer': samePlatformTransfer,
+    'cancelled': cancelled,
+    'stopovers': stopovers.map((s) => s.toJson()).toList(),
+    'occupancy': occupancy?.level.name,
+    'disruptions': disruptions,
+    'replacementDestination': replacementDestination?.toJson(),
+    'replacementArrival': replacementArrival?.toIso8601String(),
+    'replacementArrivalPlatform': replacementArrivalPlatform,
+  };
 
   factory JourneyLeg.fromJson(Map<String, dynamic> json) => JourneyLeg(
-        tripId: json['tripId'] as String?,
-        origin: Station.fromJson(json['origin'] as Map<String, dynamic>? ?? {}),
-        destination:
-            Station.fromJson(json['destination'] as Map<String, dynamic>? ?? {}),
-        departure: _parse(json['departure']),
-        plannedDeparture: _parse(json['plannedDeparture']),
-        departureDelay: json['departureDelay'] as int?,
-        departurePlatform: json['departurePlatform'] as String?,
-        plannedDeparturePlatform: json['plannedDeparturePlatform'] as String?,
-        arrival: _parse(json['arrival']),
-        plannedArrival: _parse(json['plannedArrival']),
-        arrivalDelay: json['arrivalDelay'] as int?,
-        arrivalPlatform: json['arrivalPlatform'] as String?,
-        plannedArrivalPlatform: json['plannedArrivalPlatform'] as String?,
-        line: json['line'] is Map<String, dynamic>
-            ? TransitLine.fromJson(json['line'] as Map<String, dynamic>)
-            : null,
-        direction: json['direction'] as String?,
-        isWalking: json['walking'] as bool? ?? false,
-        walkingDistance: json['distance'] as int?,
-        walkingDuration: _seconds(json['walkingSeconds']),
-        transferAvailable: _seconds(json['transferAvailableSeconds']),
-        samePlatformTransfer: json['samePlatformTransfer'] as bool? ?? false,
-        cancelled: json['cancelled'] as bool? ?? false,
-        stopovers: (json['stopovers'] as List<dynamic>? ?? [])
-            .whereType<Map<String, dynamic>>()
-            .map(LegStopover.fromJson)
-            .toList(),
-        occupancy: json['occupancy'] is String
-            ? OccupancyInfo(level: _levelByName(json['occupancy'] as String))
-            : null,
-        disruptions: (json['disruptions'] as List<dynamic>? ?? [])
-            .whereType<String>()
-            .toList(),
-        replacementDestination:
-            json['replacementDestination'] is Map<String, dynamic>
-                ? Station.fromJson(
-                    json['replacementDestination'] as Map<String, dynamic>)
-                : null,
-        replacementArrival: _parse(json['replacementArrival']),
-        replacementArrivalPlatform:
-            json['replacementArrivalPlatform'] as String?,
-      );
+    tripId: json['tripId'] as String?,
+    origin: Station.fromJson(json['origin'] as Map<String, dynamic>? ?? {}),
+    destination: Station.fromJson(
+      json['destination'] as Map<String, dynamic>? ?? {},
+    ),
+    departure: _parse(json['departure']),
+    plannedDeparture: _parse(json['plannedDeparture']),
+    departureDelay: json['departureDelay'] as int?,
+    departurePlatform: json['departurePlatform'] as String?,
+    plannedDeparturePlatform: json['plannedDeparturePlatform'] as String?,
+    arrival: _parse(json['arrival']),
+    plannedArrival: _parse(json['plannedArrival']),
+    arrivalDelay: json['arrivalDelay'] as int?,
+    arrivalPlatform: json['arrivalPlatform'] as String?,
+    plannedArrivalPlatform: json['plannedArrivalPlatform'] as String?,
+    line: json['line'] is Map<String, dynamic>
+        ? TransitLine.fromJson(json['line'] as Map<String, dynamic>)
+        : null,
+    direction: json['direction'] as String?,
+    isWalking: json['walking'] as bool? ?? false,
+    walkingDistance: json['distance'] as int?,
+    walkingDuration: _seconds(json['walkingSeconds']),
+    transferAvailable: _seconds(json['transferAvailableSeconds']),
+    samePlatformTransfer: json['samePlatformTransfer'] as bool? ?? false,
+    cancelled: json['cancelled'] as bool? ?? false,
+    stopovers: (json['stopovers'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .map(LegStopover.fromJson)
+        .toList(),
+    occupancy: json['occupancy'] is String
+        ? OccupancyInfo(level: _levelByName(json['occupancy'] as String))
+        : null,
+    disruptions: (json['disruptions'] as List<dynamic>? ?? [])
+        .whereType<String>()
+        .toList(),
+    replacementDestination:
+        json['replacementDestination'] is Map<String, dynamic>
+        ? Station.fromJson(
+            json['replacementDestination'] as Map<String, dynamic>,
+          )
+        : null,
+    replacementArrival: _parse(json['replacementArrival']),
+    replacementArrivalPlatform: json['replacementArrivalPlatform'] as String?,
+  );
 }
 
 class LegStopover {
@@ -454,28 +471,28 @@ class LegStopover {
   }
 
   Map<String, dynamic> toJson() => {
-        'stop': stop.toJson(),
-        'arrival': arrival?.toIso8601String(),
-        'departure': departure?.toIso8601String(),
-        'arrivalDelay': arrivalDelay,
-        'departureDelay': departureDelay,
-        'cancelled': cancelled,
-        'noBoarding': noBoarding,
-        'noAlighting': noAlighting,
-        'serviceNote': serviceNote,
-      };
+    'stop': stop.toJson(),
+    'arrival': arrival?.toIso8601String(),
+    'departure': departure?.toIso8601String(),
+    'arrivalDelay': arrivalDelay,
+    'departureDelay': departureDelay,
+    'cancelled': cancelled,
+    'noBoarding': noBoarding,
+    'noAlighting': noAlighting,
+    'serviceNote': serviceNote,
+  };
 
   factory LegStopover.fromJson(Map<String, dynamic> json) => LegStopover(
-        stop: Station.fromJson(json['stop'] as Map<String, dynamic>? ?? {}),
-        arrival: _parse(json['arrival']),
-        departure: _parse(json['departure']),
-        arrivalDelay: json['arrivalDelay'] as int?,
-        departureDelay: json['departureDelay'] as int?,
-        cancelled: json['cancelled'] as bool? ?? false,
-        noBoarding: json['noBoarding'] as bool? ?? false,
-        noAlighting: json['noAlighting'] as bool? ?? false,
-        serviceNote: json['serviceNote'] as String?,
-      );
+    stop: Station.fromJson(json['stop'] as Map<String, dynamic>? ?? {}),
+    arrival: _parse(json['arrival']),
+    departure: _parse(json['departure']),
+    arrivalDelay: json['arrivalDelay'] as int?,
+    departureDelay: json['departureDelay'] as int?,
+    cancelled: json['cancelled'] as bool? ?? false,
+    noBoarding: json['noBoarding'] as bool? ?? false,
+    noAlighting: json['noAlighting'] as bool? ?? false,
+    serviceNote: json['serviceNote'] as String?,
+  );
 }
 
 class JourneyPrice {
@@ -553,9 +570,9 @@ enum OccupancyLevel {
 
 /// Round-trips [OccupancyLevel] through its enum name.
 OccupancyLevel _levelByName(String name) => OccupancyLevel.values.firstWhere(
-      (l) => l.name == name,
-      orElse: () => OccupancyLevel.unknown,
-    );
+  (l) => l.name == name,
+  orElse: () => OccupancyLevel.unknown,
+);
 
 OccupancyLevel _parseLoadFactor(String factor) {
   switch (factor) {
@@ -632,7 +649,6 @@ class BikeCarriage {
     );
   }
 }
-
 
 Duration? _seconds(dynamic value) =>
     value is num ? Duration(seconds: value.toInt()) : null;

--- a/flutter-app/lib/models/journey_search.dart
+++ b/flutter-app/lib/models/journey_search.dart
@@ -1,0 +1,23 @@
+class JourneySearch {
+  final String from;
+  final String to;
+  final DateTime date;
+
+  const JourneySearch({
+    required this.from,
+    required this.to,
+    required this.date,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {'from': from, 'to': to, 'date': date.toIso8601String()};
+  }
+
+  factory JourneySearch.fromJson(Map<String, dynamic> json) {
+    return JourneySearch(
+      from: json['from'] as String,
+      to: json['to'] as String,
+      date: DateTime.parse(json['date'] as String),
+    );
+  }
+}

--- a/flutter-app/lib/models/split_ticket.dart
+++ b/flutter-app/lib/models/split_ticket.dart
@@ -60,9 +60,8 @@ class SplitTicketProgress {
     this.currentSegment = '',
   });
 
-  double get progress => totalCombinations > 0
-      ? processedCombinations / totalCombinations
-      : 0;
+  double get progress =>
+      totalCombinations > 0 ? processedCombinations / totalCombinations : 0;
 }
 
 enum BahnCardType {
@@ -77,7 +76,7 @@ enum BahnCardType {
   final String classValue;
   const BahnCardType(this.label, this.apiValue, this.classValue);
 
-  /// DB Vendo reduction token "<ART> <KLASSE>" for the `reisende` payload.
+  /// DB Vendo reduction token `ART KLASSE` for the `reisende` payload.
   String get vendoErmaessigung => this == BahnCardType.none
       ? 'KEINE_ERMAESSIGUNG KLASSENLOS'
       : '$apiValue $classValue';

--- a/flutter-app/lib/providers/journey_search_provider.dart
+++ b/flutter-app/lib/providers/journey_search_provider.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../models/station.dart';
+
 import '../core/app_log.dart';
+import '../core/journey_cache.dart';
 import '../models/journey.dart';
 import '../models/search_options.dart';
+import '../models/station.dart';
 import '../utils/arrival_buffer.dart';
 import '../utils/journey_highlights.dart';
 import 'prediction_provider.dart';
@@ -16,15 +18,12 @@ enum JourneySortMode {
   transfers,
   reliability,
 
-  /// Most slack before the appointment first. Only meaningful with a deadline
-  /// (an arrival search) — see [JourneySearchState.deadline].
+  /// Most slack before the appointment first.
+  /// Only meaningful with arrival searches.
   buffer,
 }
 
-/// Coarse transport categories for the multimodal filter. Each maps to the
-/// Vendo `VerkehrsmittelModel` values sent with the search, so the backend
-/// only ever computes the modes the user wants. The Fern/Regio split mirrors
-/// the DB Navigator's own `verkehrsmittelListFern` (ICE + IC/EC + IR).
+/// Transport categories supported by DB Vendo.
 enum ProductCategory {
   fern('Fernverkehr', [
     'HOCHGESCHWINDIGKEITSZUEGE',
@@ -38,64 +37,51 @@ enum ProductCategory {
   bus('Bus & Fähre', ['BUSSE', 'SCHIFFE']);
 
   final String label;
-
-  /// Vendo `verkehrsmittel` codes this category selects.
   final List<String> vendoCodes;
+
   const ProductCategory(this.label, this.vendoCodes);
 
-  /// The `verkehrsmittel` array for a set of categories. All categories
-  /// selected → `['ALL']`, matching the Navigator's own default request.
   static List<String> codesFor(Set<ProductCategory> cats) {
     if (cats.isEmpty || cats.length == ProductCategory.values.length) {
       return const ['ALL'];
     }
-    return [for (final c in cats) ...c.vendoCodes];
-  }
 
+    return [for (final category in cats) ...category.vendoCodes];
+  }
 }
 
 class JourneySearchState {
   final Station? from;
   final Station? to;
+
   final DateTime? dateTime;
+
   final bool isArrival;
+
   final JourneyResult? result;
+
   final bool isLoading;
+
   final String? error;
+
   final JourneySortMode sortMode;
 
-  /// Which transport categories to show. All enabled by default (full
-  /// multimodal); the user can hide modes (e.g. only Fernverkehr).
+  /// Selected transport modes.
   final Set<ProductCategory> products;
 
-  /// Only show connections the Deutschlandticket already covers. Asked for in
-  /// #18 ("existiert auf der bahn.de Website"); the backend does the work.
+  /// Deutschlandticket filter.
   final bool onlyDeutschlandTicket;
 
-  /// The transfer profile's minimum was dropped because nothing matched it —
-  /// the results below have changes this rider may not manage. Told to them
-  /// rather than silently handing back tight connections.
+  /// True when transfer profile was relaxed.
   final bool transferProfileRelaxed;
 
-  /// Max. changes / min. transfer time / via station — the backend-enforced
-  /// part of the search the rider steers (#19).
+  /// Search constraints.
   final SearchOptions options;
 
-  /// Minimum slack the rider wants in front of the appointment, in minutes.
-  /// Null = "egal". Only has meaning together with [deadline].
-  ///
-  /// A pure client-side filter, deliberately: DB has no "arrive at least N
-  /// minutes early" parameter, and shifting the requested time instead would
-  /// throw away the very connections the rider might still accept. The window
-  /// the arrival search returns already reaches back before the deadline, and
-  /// [JourneySearchNotifier.setMinBufferMinutes] pages further back when the
-  /// filter comes up empty.
+  /// Minimum buffer before appointment.
   final int? minBufferMinutes;
 
-  /// Bumped once per [JourneySearchNotifier.search] that lands results.
-  /// Deliberately NOT touched by "Früher"/"Später", which also replace
-  /// [result] — the search form folds itself away on a fresh search, and a
-  /// form the rider just reopened must survive them paging the list.
+  /// Changes every successful search.
   final int resultSerial;
 
   JourneySearchState({
@@ -115,106 +101,143 @@ class JourneySearchState {
     Set<ProductCategory>? products,
   }) : products = products ?? ProductCategory.values.toSet();
 
-  /// Whether the search should be by arrival. Only meaningful with a chosen
-  /// time — "arrive now" is nonsense, so "Jetzt" (no time) always means
-  /// departure regardless of the toggle's last value.
   bool get useArrival => dateTime != null && isArrival;
 
-  /// The time the rider has to be there by, when they searched by arrival —
-  /// "muss um 09:48 da sein". Every connection in the list is then also judged
-  /// by the slack it leaves in front of it, not only by how long it takes.
   DateTime? get deadline => useArrival ? dateTime : null;
 
-  JourneySearchState copyWith({
-    Station? from,
-    Station? to,
-    DateTime? dateTime,
-    bool? isArrival,
-    JourneyResult? result,
-    bool? isLoading,
-    String? error,
-    JourneySortMode? sortMode,
-    Set<ProductCategory>? products,
-    bool? onlyDeutschlandTicket,
-    bool? transferProfileRelaxed,
-    SearchOptions? options,
-    int? resultSerial,
-    int? minBufferMinutes,
-    bool clearDateTime = false,
-    bool clearMinBufferMinutes = false,
-  }) {
-    return JourneySearchState(
-      from: from ?? this.from,
-      to: to ?? this.to,
-      dateTime: clearDateTime ? null : (dateTime ?? this.dateTime),
-      isArrival: isArrival ?? this.isArrival,
-      result: result ?? this.result,
-      isLoading: isLoading ?? this.isLoading,
-      error: error,
-      sortMode: sortMode ?? this.sortMode,
-      products: products ?? this.products,
-      onlyDeutschlandTicket:
-          onlyDeutschlandTicket ?? this.onlyDeutschlandTicket,
-      transferProfileRelaxed:
-          transferProfileRelaxed ?? this.transferProfileRelaxed,
-      options: options ?? this.options,
-      resultSerial: resultSerial ?? this.resultSerial,
-      minBufferMinutes: clearMinBufferMinutes
-          ? null
-          : (minBufferMinutes ?? this.minBufferMinutes),
-    );
-  }
-
-  /// Whether the buffer filter is hiding connections that exist. Drives the
-  /// notice on the list: a filter that empties it must never read as "DB has
-  /// nothing".
   int get hiddenByBufferCount {
-    final all = result?.journeys.length ?? 0;
-    return all - sortedJourneys.length;
+    final total = result?.journeys.length ?? 0;
+
+    return total - sortedJourneys.length;
   }
 
   List<Journey> get sortedJourneys {
-    if (result == null) return [];
-    // No client-side product filter: the backend already searched for exactly
-    // the selected modes. Re-filtering here would drop connections it
-    // deliberately returned (e.g. a feeder bus on an otherwise regional trip).
+    if (result == null) {
+      return [];
+    }
+
     var journeys = result!.journeys.toList();
-    // The one client-side filter there is: "mind. X min Puffer". Applied before
-    // sorting so every mode below shows the same set.
+
     final deadline = this.deadline;
+
     if (deadline != null) {
       journeys = withMinBuffer(journeys, deadline, minBufferMinutes);
+
       if (sortMode == JourneySortMode.buffer) {
         return sortedByBuffer(journeys, deadline);
       }
     }
+
     switch (sortMode) {
       case JourneySortMode.departure:
-        journeys.sort((a, b) =>
-            (a.departure ?? DateTime(0)).compareTo(b.departure ?? DateTime(0)));
+        journeys.sort(
+          (a, b) => (a.departure ?? DateTime(0)).compareTo(
+            b.departure ?? DateTime(0),
+          ),
+        );
+
       case JourneySortMode.arrival:
-        journeys.sort((a, b) =>
-            (a.arrival ?? DateTime(0)).compareTo(b.arrival ?? DateTime(0)));
+        journeys.sort(
+          (a, b) =>
+              (a.arrival ?? DateTime(0)).compareTo(b.arrival ?? DateTime(0)),
+        );
+
       case JourneySortMode.duration:
-        journeys.sort((a, b) =>
-            (a.duration ?? Duration.zero).compareTo(b.duration ?? Duration.zero));
+        journeys.sort(
+          (a, b) => (a.duration ?? Duration.zero).compareTo(
+            b.duration ?? Duration.zero,
+          ),
+        );
+
       case JourneySortMode.transfers:
         journeys.sort((a, b) => a.transfers.compareTo(b.transfers));
+
       case JourneySortMode.reliability:
-        // Needs the per-journey prediction, which is async and lives in its
-        // own provider — sorted by [reliabilitySortedJourneysProvider], which
-        // starts from this (departure-ordered) list.
-        journeys.sort((a, b) =>
-            (a.departure ?? DateTime(0)).compareTo(b.departure ?? DateTime(0)));
+        journeys.sort(
+          (a, b) => (a.departure ?? DateTime(0)).compareTo(
+            b.departure ?? DateTime(0),
+          ),
+        );
+
       case JourneySortMode.buffer:
-        // Only reachable without a deadline (the case above returns) — e.g. the
-        // rider picked "Puffer" and then switched back to a departure search.
-        // Falls back to departure order instead of pretending to rank slack
-        // there is no appointment to measure against.
-        journeys.sort((a, b) =>
-            (a.departure ?? DateTime(0)).compareTo(b.departure ?? DateTime(0)));
+        journeys.sort(
+          (a, b) => (a.departure ?? DateTime(0)).compareTo(
+            b.departure ?? DateTime(0),
+          ),
+        );
     }
+
     return journeys;
+  }
+
+  JourneySearchState copyWith({
+    Station? from,
+
+    Station? to,
+
+    DateTime? dateTime,
+
+    bool? isArrival,
+
+    JourneyResult? result,
+
+    bool? isLoading,
+
+    String? error,
+
+    JourneySortMode? sortMode,
+
+    Set<ProductCategory>? products,
+
+    bool? onlyDeutschlandTicket,
+
+    bool? transferProfileRelaxed,
+
+    SearchOptions? options,
+
+    int? resultSerial,
+
+    int? minBufferMinutes,
+
+    bool clearDateTime = false,
+
+    bool clearMinBufferMinutes = false,
+
+    bool clearError = false,
+  }) {
+    return JourneySearchState(
+      from: from ?? this.from,
+
+      to: to ?? this.to,
+
+      dateTime: clearDateTime ? null : dateTime ?? this.dateTime,
+
+      isArrival: isArrival ?? this.isArrival,
+
+      result: result ?? this.result,
+
+      isLoading: isLoading ?? this.isLoading,
+
+      error: clearError ? null : error ?? this.error,
+
+      sortMode: sortMode ?? this.sortMode,
+
+      products: products ?? this.products,
+
+      onlyDeutschlandTicket:
+          onlyDeutschlandTicket ?? this.onlyDeutschlandTicket,
+
+      transferProfileRelaxed:
+          transferProfileRelaxed ?? this.transferProfileRelaxed,
+
+      options: options ?? this.options,
+
+      resultSerial: resultSerial ?? this.resultSerial,
+
+      minBufferMinutes: clearMinBufferMinutes
+          ? null
+          : minBufferMinutes ?? this.minBufferMinutes,
+    );
   }
 }
 
@@ -223,119 +246,137 @@ class JourneySearchNotifier extends Notifier<JourneySearchState> {
   JourneySearchState build() => JourneySearchState();
 
   void setFrom(Station? station) => state = state.copyWith(from: station);
+
   void setTo(Station? station) => state = state.copyWith(to: station);
+
   void setDateTime(DateTime? dt) => state = state.copyWith(dateTime: dt);
-  void setIsArrival(bool val) => state = state.copyWith(isArrival: val);
 
-  /// Back to "Jetzt": clear the chosen time and fall back to departure (an
-  /// arrival search only makes sense with a fixed time). The buffer filter goes
-  /// with it — without a deadline there is nothing to have slack in front of,
-  /// and a filter left set would silently narrow the next search.
-  void resetToNow() => state = state.copyWith(
-        clearDateTime: true,
-        isArrival: false,
-        clearMinBufferMinutes: true,
-      );
-  void setSortMode(JourneySortMode mode) =>
-      state = state.copyWith(sortMode: mode);
+  void setIsArrival(bool value) => state = state.copyWith(isArrival: value);
 
-  /// "Ich will mindestens X min Luft vor dem Termin."
-  ///
-  /// Pure filter, so it does not re-run the search — but it does page the window
-  /// backwards when nothing in it qualifies. An arrival search hands back the
-  /// connections closest to the deadline, so asking for an hour of slack can
-  /// easily hide all of them while the ones that qualify sit one "Früher" away.
-  /// Doing that by hand is the work the rider came here to avoid.
+  void resetToNow() {
+    state = state.copyWith(
+      clearDateTime: true,
+      isArrival: false,
+      clearMinBufferMinutes: true,
+    );
+  }
+
+  void setSortMode(JourneySortMode mode) {
+    state = state.copyWith(sortMode: mode);
+  }
+
   Future<void> setMinBufferMinutes(int? minutes) async {
     if (minutes == state.minBufferMinutes) return;
+
     state = state.copyWith(
       minBufferMinutes: minutes,
       clearMinBufferMinutes: minutes == null,
     );
+
     await _pageBackToBuffer();
   }
 
-  /// How many extra windows [setMinBufferMinutes] will pull in before giving up.
-  /// Each is a request; three covers the realistic jump (from "arrives 09:39" to
-  /// "arrives an hour earlier") without turning one tap into a crawl through the
-  /// timetable.
   static const int maxBufferPages = 3;
 
   Future<void> _pageBackToBuffer() async {
-    if (state.deadline == null || state.minBufferMinutes == null) return;
+    if (state.deadline == null || state.minBufferMinutes == null) {
+      return;
+    }
+
     for (var i = 0; i < maxBufferPages; i++) {
       if (state.result == null) return;
-      // Something matches — the rider has a list, stop spending requests.
-      if (state.sortedJourneys.isNotEmpty) return;
-      if (state.result!.earlierRef == null) return;
+
+      if (state.sortedJourneys.isNotEmpty) {
+        return;
+      }
+
+      if (state.result!.earlierRef == null) {
+        return;
+      }
+
       final before = state.result!.journeys.length;
+
       await loadEarlier();
-      // The window didn't grow: this end of the timetable is exhausted (or the
-      // page failed), and looping again would just repeat the same request.
-      if ((state.result?.journeys.length ?? 0) <= before) return;
+
+      if ((state.result?.journeys.length ?? 0) <= before) {
+        return;
+      }
     }
   }
 
-  /// Toggle a transport category in the multimodal filter. Never lets the user
-  /// deselect the last category (that would hide everything) — re-enabling all
-  /// instead. The filter is part of the query, so this re-runs the search.
-  void toggleProduct(ProductCategory cat) {
+  void toggleProduct(ProductCategory category) {
     final next = Set<ProductCategory>.from(state.products);
-    if (!next.remove(cat)) next.add(cat);
-    if (next.isEmpty) next.addAll(ProductCategory.values);
+
+    if (!next.remove(category)) {
+      next.add(category);
+    }
+
+    if (next.isEmpty) {
+      next.addAll(ProductCategory.values);
+    }
+
     state = state.copyWith(products: next);
-    if (state.result != null) search();
+
+    if (state.result != null) {
+      search();
+    }
   }
 
   void setAllProducts() {
     state = state.copyWith(products: ProductCategory.values.toSet());
-    if (state.result != null) search();
+
+    if (state.result != null) {
+      search();
+    }
   }
 
-  /// Restrict the search to Deutschlandticket-covered connections. Like the
-  /// product filter this is part of the query, so it re-runs the search.
   void toggleOnlyDeutschlandTicket() {
-    state = state.copyWith(
-        onlyDeutschlandTicket: !state.onlyDeutschlandTicket);
-    if (state.result != null) search();
+    state = state.copyWith(onlyDeutschlandTicket: !state.onlyDeutschlandTicket);
+
+    if (state.result != null) {
+      search();
+    }
   }
 
-  /// Apply max. changes / min. transfer time / via (#19). Backend-enforced, so
-  /// like the other query parts this re-runs the search — but only if the
-  /// options actually changed, since the sheet applies on every close.
   void setOptions(SearchOptions options) {
     if (options == state.options) return;
+
     state = state.copyWith(options: options);
-    if (state.result != null) search();
+
+    if (state.result != null) {
+      search();
+    }
   }
 
   void swapStations() {
     state = state.copyWith(from: state.to, to: state.from);
   }
 
-  /// Search with optional text fallback for unresolved station names
   Future<void> search({String? fromText, String? toText}) async {
     state = state.copyWith(isLoading: true, error: null);
 
     try {
       final hafas = ref.read(hafasServiceProvider);
 
-      // Auto-resolve stations from text if not selected from dropdown
       var from = state.from;
       var to = state.to;
 
       if (from == null && fromText != null && fromText.trim().length >= 2) {
         final results = await hafas.searchStations(fromText.trim());
+
         if (results.isNotEmpty) {
           from = results.first;
+
           state = state.copyWith(from: from);
         }
       }
 
       if (to == null && toText != null && toText.trim().length >= 2) {
         final results = await hafas.searchStations(toText.trim());
+
         if (results.isNotEmpty) {
           to = results.first;
+
           state = state.copyWith(to: to);
         }
       }
@@ -346,149 +387,192 @@ class JourneySearchNotifier extends Notifier<JourneySearchState> {
           error: from == null && to == null
               ? 'Start und Ziel eingeben.'
               : from == null
-                  ? 'Startstation nicht gefunden.'
-                  : 'Zielstation nicht gefunden.',
+              ? 'Startstation nicht gefunden.'
+              : 'Zielstation nicht gefunden.',
         );
+
         return;
       }
 
-      AppLog.log('search ${from.name} (${from.id}) → ${to.name} (${to.id}) '
-          'at ${state.dateTime ?? "now"} '
-          '${state.useArrival ? "[arrival]" : "[departure]"}', tag: 'journey');
+      final cacheKey = JourneyCache.key(
+        from: from.id,
+        to: to.id,
+        dateTime: state.dateTime ?? DateTime.now(),
+        arrival: state.useArrival,
+      );
 
-      // DB Vendo (DB Navigator backend) is the only working journey source:
-      // it returns journeys WITH prices and is not Akamai-gated. The old
-      // bahn.de-website journey POST (OPS_BLOCKED) and the public HAFAS mirror
-      // (chronically down) were removed — they never succeeded and only added a
-      // multi-second hang before the real error surfaced.
+      final cached = await JourneyCache.read(cacheKey);
+
+      if (cached != null) {
+        AppLog.log('loaded journey from offline cache', tag: 'offline');
+
+        state = state.copyWith(result: cached, isLoading: false);
+
+        // Cache hit:
+        // keep cached result instead of blocking user
+        // with another network request.
+        return;
+      }
+
+      AppLog.log(
+        'search ${from.name} (${from.id}) → '
+        '${to.name} (${to.id})',
+        tag: 'journey',
+      );
+
       final vendo = ref.read(vendoServiceProvider);
+
       final settings = ref.read(settingsProvider);
+
       final party = settings.searchParty;
+
       final options = state.options;
-      // Ask DB for transfers this rider can actually make, instead of judging
-      // 5-minute changes after the fact (#19). An explicit wish from the
-      // options sheet wins over the profile's guess; null for fast/normal.
+
       final fromProfile = options.minTransferMinutes == null;
-      final minTransfer = options.minTransferMinutes ??
+
+      final minTransfer =
+          options.minTransferMinutes ??
           settings.transferProfile.minTransferMinutes;
 
-      Future<JourneyResult> run({int? minTransferMinutes}) =>
-          vendo.searchJourneys(
-            fromLocationId: from!.vendoLocationId,
-            toLocationId: to!.vendoLocationId,
-            dateTime: state.dateTime ?? DateTime.now(),
-            isArrival: state.useArrival,
-            firstClass: party.firstClass,
-            reisende: party.toReisendeJson(),
-            deutschlandTicket: party.deutschlandTicket,
-            verkehrsmittel: ProductCategory.codesFor(state.products),
-            nurDeutschlandTicketVerbindungen: state.onlyDeutschlandTicket,
-            minTransferMinutes: minTransferMinutes,
-            maxTransfers: options.maxTransfers,
-            viaLocations: options.viaLocationsJson,
-          );
+      Future<JourneyResult> run({int? minTransferMinutes}) {
+        return vendo.searchJourneys(
+          fromLocationId: from!.vendoLocationId,
+
+          toLocationId: to!.vendoLocationId,
+
+          dateTime: state.dateTime ?? DateTime.now(),
+
+          isArrival: state.useArrival,
+
+          firstClass: party.firstClass,
+
+          reisende: party.toReisendeJson(),
+
+          deutschlandTicket: party.deutschlandTicket,
+
+          verkehrsmittel: ProductCategory.codesFor(state.products),
+
+          nurDeutschlandTicketVerbindungen: state.onlyDeutschlandTicket,
+
+          minTransferMinutes: minTransferMinutes,
+
+          maxTransfers: options.maxTransfers,
+
+          viaLocations: options.viaLocationsJson,
+        );
+      }
 
       var result = await run(minTransferMinutes: minTransfer);
+
       var relaxed = false;
-      // A profile that's too demanding for the route comes back empty — the
-      // backend answers an impossible constraint with an empty list, not an
-      // error. Showing "nothing found" would be a lie: connections exist, they
-      // just have tight changes. Retry unconstrained and say so.
-      //
-      // Only for the *profile's* minimum. A number the rider typed into the
-      // options sheet is a filter like any other — quietly ignoring it would
-      // be worse than an empty list they know how to widen.
+
       if (result.journeys.isEmpty && minTransfer != null && fromProfile) {
-        AppLog.log('no journeys with minUmstiegsdauer=$minTransfer — retrying',
-            tag: 'journey');
         result = await run();
+
         relaxed = result.journeys.isNotEmpty;
       }
-      AppLog.log('vendo result: ${result.journeys.length} journeys'
-          '${relaxed ? " (profile relaxed)" : ""}', tag: 'journey');
+
+      // NEW:
+      // Save fresh result offline.
+      await JourneyCache.write(cacheKey, result);
+
       state = state.copyWith(
-          result: result,
-          isLoading: false,
-          transferProfileRelaxed: relaxed,
-          resultSerial: state.resultSerial + 1);
+        result: result,
+        isLoading: false,
+        transferProfileRelaxed: relaxed,
+        resultSerial: state.resultSerial + 1,
+      );
     } catch (e) {
       AppLog.log('search FAILED: $e', tag: 'journey');
+
       state = state.copyWith(error: 'Fehler: $e', isLoading: false);
     }
   }
 
-  /// Load earlier connections by replaying the Vendo `frueherContext` token,
-  /// prepending the (deduped) results and advancing the earlier token.
   Future<void> loadEarlier() => _loadMore(earlier: true);
 
-  /// Load later connections via the `spaeterContext` token.
   Future<void> loadLater() => _loadMore(earlier: false);
 
   Future<void> _loadMore({required bool earlier}) async {
     final current = state.result;
+
     final token = earlier ? current?.earlierRef : current?.laterRef;
-    if (token == null || state.from == null || state.to == null) return;
+
+    if (token == null || state.from == null || state.to == null) {
+      return;
+    }
 
     state = state.copyWith(isLoading: true, error: null);
+
     try {
       final vendo = ref.read(vendoServiceProvider);
+
       final settings = ref.read(settingsProvider);
+
       final party = settings.searchParty;
+
       final options = state.options;
-      // The constraints have to travel with the paged request too — the
-      // context token scrolls the window, it doesn't carry the wish. Without
-      // them, "Später" would append the very 5-minute changes the first page
-      // was searched to avoid.
-      //
-      // Deliberately no relax-retry here: an empty page means this end of the
-      // window has nothing left, not that the profile is too strict — the
-      // first page already proved connections exist.
+
       final more = await vendo.searchJourneys(
         fromLocationId: state.from!.vendoLocationId,
+
         toLocationId: state.to!.vendoLocationId,
+
         dateTime: state.dateTime ?? DateTime.now(),
+
         isArrival: state.useArrival,
+
         context: token,
+
         firstClass: party.firstClass,
+
         reisende: party.toReisendeJson(),
+
         deutschlandTicket: party.deutschlandTicket,
+
         verkehrsmittel: ProductCategory.codesFor(state.products),
+
         nurDeutschlandTicketVerbindungen: state.onlyDeutschlandTicket,
+
         minTransferMinutes: state.transferProfileRelaxed
             ? null
             : options.minTransferMinutes ??
-                settings.transferProfile.minTransferMinutes,
+                  settings.transferProfile.minTransferMinutes,
+
         maxTransfers: options.maxTransfers,
+
         viaLocations: options.viaLocationsJson,
       );
 
-      // Dedupe against what we already show (paged windows can overlap).
       final existing = current?.journeys ?? const [];
+
       final seen = existing.map(_journeyKey).toSet();
-      final fresh =
-          more.journeys.where((j) => seen.add(_journeyKey(j))).toList();
+
+      final fresh = more.journeys
+          .where((j) => seen.add(_journeyKey(j)))
+          .toList();
 
       final combined = JourneyResult(
-        journeys: earlier
-            ? [...fresh, ...existing]
-            : [...existing, ...fresh],
-        // Advance only the token we scrolled; keep the other end intact.
+        journeys: earlier ? [...fresh, ...existing] : [...existing, ...fresh],
+
         earlierRef: earlier ? more.earlierRef : current?.earlierRef,
+
         laterRef: earlier ? current?.laterRef : more.laterRef,
       );
+
       state = state.copyWith(result: combined, isLoading: false);
     } catch (e) {
-      AppLog.log('loadMore(${earlier ? "earlier" : "later"}) failed: $e',
-          tag: 'journey');
+      AppLog.log('loadMore failed: $e', tag: 'journey');
+
       state = state.copyWith(isLoading: false);
     }
   }
 
-  /// Stable identity for a journey, to dedupe overlapping paged windows.
   String _journeyKey(Journey j) =>
       j.refreshToken ??
-      '${j.departure?.toIso8601String()}|${j.arrival?.toIso8601String()}'
-          '|${j.legs.firstOrNull?.line?.name ?? ''}';
+      '${j.departure?.toIso8601String()}|'
+          '${j.arrival?.toIso8601String()}|'
+          '${j.legs.firstOrNull?.line?.name ?? ''}';
 
   void clear() {
     state = JourneySearchState();
@@ -497,62 +581,66 @@ class JourneySearchNotifier extends Notifier<JourneySearchState> {
 
 final journeySearchProvider =
     NotifierProvider<JourneySearchNotifier, JourneySearchState>(
-        JourneySearchNotifier.new);
+      JourneySearchNotifier.new,
+    );
 
-/// Which connection is the fastest / cheapest / safest / best compromise of
-/// the current result list (#11, point 9).
-///
-/// Reads the same per-journey predictions the badges and the reliability sort
-/// already request, so the labels fill in as those land — no extra traffic.
 final journeyHighlightsProvider =
     Provider.autoDispose<Map<JourneyHighlight, Journey>>((ref) {
-  final journeys = ref.watch(journeySearchProvider).sortedJourneys;
-  return journeyHighlights(
-    journeys,
-    (j) => ref
-        .watch(journeyPredictionProvider(PredictionRequest(j)))
-        .asData
-        ?.value
-        ?.reliabilityScore,
-  );
-});
+      final journeys = ref.watch(journeySearchProvider).sortedJourneys;
 
-/// The result list the UI renders — [JourneySearchState.sortedJourneys], except
-/// in `reliability` mode, where it's re-ordered by the prediction model.
-///
-/// Separate from the state getter because the score is async: each journey's
-/// prediction is its own request. Predictions stream in, so the list settles
-/// rather than appearing sorted at once — journeys still waiting on (or
-/// missing) a score keep their departure order at the bottom instead of
-/// jumping around. The requests are the same ones the badges already make, so
-/// this mode costs nothing extra.
-final reliabilitySortedJourneysProvider =
-    Provider.autoDispose<List<Journey>>((ref) {
+      return journeyHighlights(
+        journeys,
+        (j) => ref
+            .watch(journeyPredictionProvider(PredictionRequest(j)))
+            .asData
+            ?.value
+            ?.reliabilityScore,
+      );
+    });
+
+final reliabilitySortedJourneysProvider = Provider.autoDispose<List<Journey>>((
+  ref,
+) {
   final state = ref.watch(journeySearchProvider);
+
   final journeys = state.sortedJourneys;
-  if (state.sortMode != JourneySortMode.reliability) return journeys;
+
+  if (state.sortMode != JourneySortMode.reliability) {
+    return journeys;
+  }
 
   final scored = <({Journey journey, double? score, int order})>[
     for (final (i, j) in journeys.indexed)
       (
         journey: j,
+
         score: ref
             .watch(journeyPredictionProvider(PredictionRequest(j)))
             .asData
             ?.value
             ?.reliabilityScore,
+
         order: i,
       ),
   ];
-  // The index tiebreaker keeps this stable (List.sort isn't), so equal or
-  // still-unscored connections hold their departure order instead of shuffling
-  // on every rebuild as predictions land.
+
   scored.sort((a, b) {
-    if (a.score == null && b.score == null) return a.order.compareTo(b.order);
-    if (a.score == null) return 1; // unscored last — not "least reliable"
-    if (b.score == null) return -1;
-    final byScore = b.score!.compareTo(a.score!); // most reliable first
-    return byScore != 0 ? byScore : a.order.compareTo(b.order);
+    if (a.score == null && b.score == null) {
+      return a.order.compareTo(b.order);
+    }
+
+    if (a.score == null) {
+      return 1;
+    }
+
+    if (b.score == null) {
+      return -1;
+    }
+
+    final score = b.score!.compareTo(a.score!);
+
+    return score != 0 ? score : a.order.compareTo(b.order);
   });
-  return [for (final e in scored) e.journey];
+
+  return [for (final item in scored) item.journey];
 });

--- a/flutter-app/lib/providers/journey_search_provider.dart
+++ b/flutter-app/lib/providers/journey_search_provider.dart
@@ -2,7 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/app_log.dart';
 import '../core/journey_cache.dart';
+import '../core/search_history_cache.dart';
 import '../models/journey.dart';
+import '../models/journey_search.dart';
 import '../models/search_options.dart';
 import '../models/station.dart';
 import '../utils/arrival_buffer.dart';
@@ -242,6 +244,7 @@ class JourneySearchState {
 }
 
 class JourneySearchNotifier extends Notifier<JourneySearchState> {
+  final SearchHistoryCache _historyCache = SearchHistoryCache();
   @override
   JourneySearchState build() => JourneySearchState();
 
@@ -368,6 +371,13 @@ class JourneySearchNotifier extends Notifier<JourneySearchState> {
           from = results.first;
 
           state = state.copyWith(from: from);
+          await _historyCache.add(
+            JourneySearch(
+              from: state.from?.name ?? '',
+              to: state.to?.name ?? '',
+              date: state.dateTime ?? DateTime.now(),
+            ),
+          );
         }
       }
 

--- a/flutter-app/lib/router/app_router.dart
+++ b/flutter-app/lib/router/app_router.dart
@@ -2,31 +2,31 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../models/journey.dart';
 import '../providers/onboarding_provider.dart';
+import '../screens/connection_search/best_price_screen.dart';
+import '../screens/connection_search/connection_detail_screen.dart';
+// import '../screens/connection_search/connection_detail_screen.dart' show TicketRef;
+import '../screens/connection_search/connection_search_screen.dart';
+import '../screens/connection_search/stopover_plan_screen.dart';
+import '../screens/debug_log/debug_log_screen.dart';
 import '../screens/home/home_screen.dart';
-import '../screens/onboarding/onboarding_screen.dart';
 import '../screens/journeys/journeys_screen.dart';
 import '../screens/nearby/nearby_screen.dart';
-import '../screens/train_lookup/train_lookup_screen.dart';
+import '../screens/onboarding/onboarding_screen.dart';
 import '../screens/profile/profile_screen.dart';
 import '../screens/profile/ticket_detail_screen.dart';
-import '../screens/connection_search/connection_detail_screen.dart' show TicketRef;
-import '../screens/connection_search/connection_search_screen.dart';
-import '../screens/connection_search/best_price_screen.dart';
-import '../screens/connection_search/stopover_plan_screen.dart';
-import '../screens/station_map/station_map_screen.dart';
-import '../screens/connection_search/connection_detail_screen.dart';
-import '../models/journey.dart';
-import 'tab_pager.dart';
-import '../screens/split_ticket/split_ticket_screen.dart';
-import '../screens/split_ticket/bulk_split_screen.dart';
 import '../screens/settings/settings_screen.dart';
+import '../screens/split_ticket/bulk_split_screen.dart';
+import '../screens/split_ticket/split_ticket_screen.dart';
+import '../screens/station_map/station_map_screen.dart';
 import '../screens/stats/travel_stats_screen.dart';
-import '../screens/debug_log/debug_log_screen.dart';
-import '../screens/traewelling/traewelling_hub_screen.dart';
+import '../screens/traewelling/traewelling_checkin_screen.dart';
 import '../screens/traewelling/traewelling_feed_screen.dart';
 import '../screens/traewelling/traewelling_friends_screen.dart';
-import '../screens/traewelling/traewelling_checkin_screen.dart';
+import '../screens/traewelling/traewelling_hub_screen.dart';
+import '../screens/train_lookup/train_lookup_screen.dart';
+import 'tab_pager.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
@@ -239,8 +239,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) {
           final args = state.extra as BestPriceArgs;
-          return BestPriceScreen(
-              from: args.from, to: args.to, date: args.date);
+          return BestPriceScreen(from: args.from, to: args.to, date: args.date);
         },
       ),
       // A single train's run, pushed (with back button) from a connection leg

--- a/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
+++ b/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/app_log.dart';
 import '../../core/extensions.dart';
 import '../../core/missed_connection.dart';
-import '../../core/trip_metrics.dart';
 import '../../core/share_text.dart';
+import '../../core/trip_metrics.dart';
 import '../../models/coach_sequence.dart';
 import '../../models/journey.dart';
 import '../../models/library_models.dart';
@@ -17,30 +19,26 @@ import '../../models/station.dart';
 import '../../models/station_map.dart';
 import '../../models/transfer_profile.dart';
 import '../../models/trip.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:url_launcher/url_launcher.dart';
-
-import '../../providers/library_provider.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/journey_search_provider.dart';
+import '../../providers/library_provider.dart';
+import '../../providers/regional_transit_provider.dart';
 import '../../providers/service_providers.dart';
 import '../../providers/settings_provider.dart';
 import '../../providers/split_ticket_provider.dart';
-import '../../providers/regional_transit_provider.dart';
 import '../../providers/station_map_provider.dart';
 import '../../providers/stopover_plan_provider.dart';
 import '../../providers/travel_stats_provider.dart';
 import '../../services/db_api_service.dart';
+import '../../services/notification_service.dart';
 import '../../services/regional_transit_service.dart'
     show RegionalTransitService, PlatformCorrection;
-import '../../services/notification_service.dart';
 import '../../theme/app_colors.dart';
-import '../../widgets/ui/message_card.dart';
 import '../../utils/earlier_alight.dart';
 import '../../utils/leg_swap.dart';
 import '../../utils/plain_language.dart';
-import '../../utils/transfer_risk.dart';
 import '../../utils/split_stops.dart';
+import '../../utils/transfer_risk.dart';
 import '../../widgets/departure_card.dart';
 import '../../widgets/fahrgastrechte_card.dart';
 import '../../widgets/offline_package_bar.dart';
@@ -48,6 +46,7 @@ import '../../widgets/prediction_badge.dart';
 import '../../widgets/product_badge.dart';
 import '../../widgets/trip_progress_inline.dart';
 import '../../widgets/trwl_checkin_sheet.dart';
+import '../../widgets/ui/message_card.dart';
 import '../train_lookup/widgets/train_detail_view.dart';
 import 'widgets/leg_switcher.dart';
 import 'widgets/transfer_coach_hint.dart';
@@ -144,16 +143,21 @@ class _ConnectionDetailScreenState
     if (index < 0 || index >= legs.length) return;
     final old = legs[index];
     legs[index] = newLeg;
-    _adoptJourney(Journey(legs: legs)); // price/refreshToken intentionally dropped
+    _adoptJourney(
+      Journey(legs: legs),
+    ); // price/refreshToken intentionally dropped
 
     // Taking a later (or earlier) train on Kiel→München does not only change
     // that leg — everything behind it moves with it. The old onward legs
     // describe trains that have long gone, or that the rider now waits an hour
     // for, so they are re-planned from the new arrival (#55-Umstieg).
     final newArrival = newLeg.arrival ?? newLeg.plannedArrival;
-    if (tailNeedsReplan(legs, index,
-        oldArrival: old.arrival ?? old.plannedArrival,
-        newArrival: newArrival)) {
+    if (tailNeedsReplan(
+      legs,
+      index,
+      oldArrival: old.arrival ?? old.plannedArrival,
+      newArrival: newArrival,
+    )) {
       _replanTail(index, newArrival!);
       return;
     }
@@ -185,7 +189,9 @@ class _ConnectionDetailScreenState
     _snack('Fahrt ersetzt · Anschlüsse werden neu gesucht …');
     try {
       final settings = ref.read(settingsProvider);
-      final res = await ref.read(vendoServiceProvider).searchJourneys(
+      final res = await ref
+          .read(vendoServiceProvider)
+          .searchJourneys(
             fromLocationId: from.vendoLocationId,
             toLocationId: to.vendoLocationId,
             dateTime: arrival,
@@ -199,11 +205,15 @@ class _ConnectionDetailScreenState
         _snack('Keine Anschlüsse ab ${from.name} gefunden — bitte prüfen');
         return;
       }
-      _adoptJourney(Journey(legs: spliceTail(legs, index, onward)),
-          refresh: true);
+      _adoptJourney(
+        Journey(legs: spliceTail(legs, index, onward)),
+        refresh: true,
+      );
       final arr = onward.arrival ?? onward.plannedArrival;
-      _snack('Anschlüsse neu gesucht'
-          '${arr != null ? ' · Ankunft ${arr.hhmm}' : ''}');
+      _snack(
+        'Anschlüsse neu gesucht'
+        '${arr != null ? ' · Ankunft ${arr.hhmm}' : ''}',
+      );
     } catch (e) {
       AppLog.log('replan after leg swap failed: $e', tag: 'trip-detail');
       if (!mounted) return;
@@ -220,10 +230,9 @@ class _ConnectionDetailScreenState
     if (!mounted) return;
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(
-        duration: const Duration(seconds: 4),
-        content: Text(text),
-      ));
+      ..showSnackBar(
+        SnackBar(duration: const Duration(seconds: 4), content: Text(text)),
+      );
   }
 
   /// Rescue option B for the transfer into leg [i] (#26): what the switcher
@@ -234,7 +243,10 @@ class _ConnectionDetailScreenState
   /// the trip cache — the freshest live times of the ridden train, re-fetched
   /// around every stop, versus the search's realtime snapshot.
   EarlierAlightInput? _earlierAlightInput(
-      List<JourneyLeg> legs, int i, JourneyLeg? prev) {
+    List<JourneyLeg> legs,
+    int i,
+    JourneyLeg? prev,
+  ) {
     if (prev == null) return null;
     final destination = journey.destination;
     if (destination == null || destination.vendoLocationId.isEmpty) return null;
@@ -267,20 +279,22 @@ class _ConnectionDetailScreenState
       option: option,
     );
     if (legs == null) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-        content: Text('Route konnte nicht übernommen werden.'),
-      ));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Route konnte nicht übernommen werden.')),
+      );
       return;
     }
     // price/refreshToken intentionally dropped
     _adoptJourney(Journey(legs: legs), refresh: true);
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      duration: const Duration(seconds: 5),
-      content: Text(
-        'Neue Route ab ${option.stop.station.name}'
-        '${option.ticketNote == AlightTicketNote.dTicketCovered ? '' : ' · ${option.ticketNote.label}'}',
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        duration: const Duration(seconds: 5),
+        content: Text(
+          'Neue Route ab ${option.stop.station.name}'
+          '${option.ticketNote == AlightTicketNote.dTicketCovered ? '' : ' · ${option.ticketNote.label}'}',
+        ),
       ),
-    ));
+    );
   }
 
   /// First non-walking leg after [i], or null — the train this leg connects to.
@@ -318,8 +332,7 @@ class _ConnectionDetailScreenState
             IconButton(
               icon: const Icon(Icons.qr_code_2),
               tooltip: 'Ticket anzeigen',
-              onPressed: () =>
-                  context.push('/ticket-view', extra: ticketRef),
+              onPressed: () => context.push('/ticket-view', extra: ticketRef),
             ),
           // Teilen + Öffnen folded into one button → a small menu asks which.
           PopupMenuButton<int>(
@@ -404,76 +417,86 @@ class _ConnectionDetailScreenState
           // trip is saved locally (there's nothing to track otherwise, and the
           // tracker reads the local library). Explicit and trip-scoped, per
           // the privacy ask in #11.
-          Builder(builder: (context) {
-            final key = SavedJourney(journey: journey, savedAtMs: 0).key;
-            final lib = ref.watch(libraryProvider);
-            if (!lib.hasJourney(key)) return const SizedBox.shrink();
-            final watched =
-                ref.read(libraryProvider.notifier).isJourneyWatched(key);
-            return IconButton(
-              icon: Icon(watched
-                  ? Icons.notifications_active
-                  : Icons.notifications_off_outlined),
-              tooltip: watched
-                  ? 'Benachrichtigungen aktiv — antippen zum Ausschalten'
-                  : 'Diese Reise überwachen',
-              onPressed: () {
-                ref
-                    .read(libraryProvider.notifier)
-                    .setJourneyWatched(key, !watched);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: const Duration(seconds: 3),
-                    content: Text(watched
-                        ? 'Benachrichtigungen für diese Reise aus.'
-                        : 'Benachrichtigungen an: Erinnerungen, Verspätung, '
-                            'Gleiswechsel, Ausfall & Anschluss.'),
-                  ),
-                );
-                if (!watched) NotificationService.requestPermissions();
-              },
-            );
-          }),
-          Builder(builder: (context) {
-            final key =
-                SavedJourney(journey: journey, savedAtMs: 0).key;
-            // A trip saved to the DB account but no longer in the local
-            // library still IS saved — showing an empty bookmark there made it
-            // un-removable, and tapping it created a *second* DB trip (#15).
-            final saved = ref.watch(libraryProvider).hasJourney(key) ||
-                ref.watch(dbSavedReiseIdsProvider).containsKey(key);
-            return IconButton(
-              icon: Icon(saved ? Icons.bookmark : Icons.bookmark_border),
-              tooltip: saved ? 'Reise entfernen' : 'Reise speichern',
-              onPressed: () {
-                final wasSaved = saved;
-                // Explicit add/remove, not toggle: when the trip is saved in
-                // the DB account but absent locally, a local toggle would ADD
-                // it — the opposite of what the filled bookmark promises.
-                if (wasSaved) {
-                  ref.read(libraryProvider.notifier).removeJourney(key);
-                } else {
-                  ref.read(libraryProvider.notifier).toggleJourney(journey);
-                }
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: const Duration(seconds: 2),
-                    content:
-                        Text(wasSaved ? 'Reise entfernt' : 'Reise gespeichert'),
-                  ),
-                );
-                // Saving + 'Automatisch einchecken' on → also push the trip's
-                // train legs to Träwelling. No-op when off / not connected.
-                if (!wasSaved) {
-                  autoCheckinSavedJourney(context, ref, journey);
-                }
-                // When signed into a DB account, mirror the bookmark to the
-                // official "Meine Reisen" so it also lives in the DB account
-                // (and gets DB's delay tracking). Best-effort, never blocks UI.
-                _syncDbReise(ref, key, saved: !wasSaved);
-              },
-            );
-          }),
+          Builder(
+            builder: (context) {
+              final key = SavedJourney(journey: journey, savedAtMs: 0).key;
+              final lib = ref.watch(libraryProvider);
+              if (!lib.hasJourney(key)) return const SizedBox.shrink();
+              final watched = ref
+                  .read(libraryProvider.notifier)
+                  .isJourneyWatched(key);
+              return IconButton(
+                icon: Icon(
+                  watched
+                      ? Icons.notifications_active
+                      : Icons.notifications_off_outlined,
+                ),
+                tooltip: watched
+                    ? 'Benachrichtigungen aktiv — antippen zum Ausschalten'
+                    : 'Diese Reise überwachen',
+                onPressed: () {
+                  ref
+                      .read(libraryProvider.notifier)
+                      .setJourneyWatched(key, !watched);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      duration: const Duration(seconds: 3),
+                      content: Text(
+                        watched
+                            ? 'Benachrichtigungen für diese Reise aus.'
+                            : 'Benachrichtigungen an: Erinnerungen, Verspätung, '
+                                  'Gleiswechsel, Ausfall & Anschluss.',
+                      ),
+                    ),
+                  );
+                  if (!watched) NotificationService.requestPermissions();
+                },
+              );
+            },
+          ),
+          Builder(
+            builder: (context) {
+              final key = SavedJourney(journey: journey, savedAtMs: 0).key;
+              // A trip saved to the DB account but no longer in the local
+              // library still IS saved — showing an empty bookmark there made it
+              // un-removable, and tapping it created a *second* DB trip (#15).
+              final saved =
+                  ref.watch(libraryProvider).hasJourney(key) ||
+                  ref.watch(dbSavedReiseIdsProvider).containsKey(key);
+              return IconButton(
+                icon: Icon(saved ? Icons.bookmark : Icons.bookmark_border),
+                tooltip: saved ? 'Reise entfernen' : 'Reise speichern',
+                onPressed: () {
+                  final wasSaved = saved;
+                  // Explicit add/remove, not toggle: when the trip is saved in
+                  // the DB account but absent locally, a local toggle would ADD
+                  // it — the opposite of what the filled bookmark promises.
+                  if (wasSaved) {
+                    ref.read(libraryProvider.notifier).removeJourney(key);
+                  } else {
+                    ref.read(libraryProvider.notifier).toggleJourney(journey);
+                  }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      duration: const Duration(seconds: 2),
+                      content: Text(
+                        wasSaved ? 'Reise entfernt' : 'Reise gespeichert',
+                      ),
+                    ),
+                  );
+                  // Saving + 'Automatisch einchecken' on → also push the trip's
+                  // train legs to Träwelling. No-op when off / not connected.
+                  if (!wasSaved) {
+                    autoCheckinSavedJourney(context, ref, journey);
+                  }
+                  // When signed into a DB account, mirror the bookmark to the
+                  // official "Meine Reisen" so it also lives in the DB account
+                  // (and gets DB's delay tracking). Best-effort, never blocks UI.
+                  _syncDbReise(ref, key, saved: !wasSaved);
+                },
+              );
+            },
+          ),
         ],
       ),
       body: RefreshIndicator(
@@ -481,110 +504,121 @@ class _ConnectionDetailScreenState
         // leg sections fresh (new keys), so all live data re-fetches.
         onRefresh: _refreshAll,
         child: ListView(
-        padding: const EdgeInsets.only(bottom: 32),
-        // Always scrollable so the pull-to-refresh gesture works even when the
-        // content is short.
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: [
-          _summary(context),
-          _ownExperience(context),
-          _bikeNotice(context),
-          // Offline, the legs below are replayed from this journey's package
-          // (see the fallbacks in HafasService/CoachSequenceService/
-          // StationMapService). Say how old they are — cached data presented
-          // without its age is exactly what makes people distrust it (#29).
-          OfflineDataNotice(
-            journeyKey: SavedJourney(journey: journey, savedAtMs: 0).key,
-          ),
-          if (journey.hasCancelledLeg)
-            const _JourneyCancelBanner(partial: false)
-          else if (journey.hasPartialCancellation)
-            const _JourneyCancelBanner(partial: true),
-          // Notes about the connection as a whole, above the legs because they
-          // can be the only place saying what changed ("Der Zielhalt Berlin
-          // Hbf entfällt. Ausstieg in Berlin-Spandau möglich.") — the legs
-          // themselves sometimes carry nothing.
-          _LegNotes(notes: _visibleNotes(journey.disruptions)),
-          _serviceDays(context),
-          _buyButton(context, ref),
-          // Live companion cards (each self-hides when not applicable):
-          // Fahrgastrechte claim on a 60+ min late arrival, and one combined
-          // pre-departure card (countdown + "wann musst du los") that
-          // disappears once the train has left. The on-board progress lives
-          // folded into the summary block above (TripProgressInline).
-          FahrgastrechteCard(journey: journey),
-          DepartureCard(journey: journey),
-          if (missed != null)
-            _MissedConnectionCard(
-              rescue: missed,
-              onPressed: () =>
-                  _showMissedAlternatives(context, ref, missed),
+          padding: const EdgeInsets.only(bottom: 32),
+          // Always scrollable so the pull-to-refresh gesture works even when the
+          // content is short.
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            _summary(context),
+            _ownExperience(context),
+            _bikeNotice(context),
+            // Offline, the legs below are replayed from this journey's package
+            // (see the fallbacks in HafasService/CoachSequenceService/
+            // StationMapService). Say how old they are — cached data presented
+            // without its age is exactly what makes people distrust it (#29).
+            OfflineDataNotice(
+              journeyKey: SavedJourney(journey: journey, savedAtMs: 0).key,
             ),
-          // The legs behind a swapped one are the OLD plan until the re-search
-          // lands — say so rather than let them read as checked (#55-Umstieg).
-          if (_replanning)
-            const MessageCard(
-              tone: MessageTone.info,
-              body: 'Anschlüsse werden für die neue Ankunft gesucht …',
-            ),
-          for (var i = 0; i < legs.length; i++) ...[
-            if (i > 0) _transfer(context, ref, legs[i - 1], legs[i]),
-            if (legs[i].isWalking)
-              _walkLeg(context, ref, legs[i],
+            if (journey.hasCancelledLeg)
+              const _JourneyCancelBanner(partial: false)
+            else if (journey.hasPartialCancellation)
+              const _JourneyCancelBanner(partial: true),
+            // Notes about the connection as a whole, above the legs because they
+            // can be the only place saying what changed ("Der Zielhalt Berlin
+            // Hbf entfällt. Ausstieg in Berlin-Spandau möglich.") — the legs
+            // themselves sometimes carry nothing.
+            _LegNotes(notes: _visibleNotes(journey.disruptions)),
+            _serviceDays(context),
+            _buyButton(context, ref),
+            // Live companion cards (each self-hides when not applicable):
+            // Fahrgastrechte claim on a 60+ min late arrival, and one combined
+            // pre-departure card (countdown + "wann musst du los") that
+            // disappears once the train has left. The on-board progress lives
+            // folded into the summary block above (TripProgressInline).
+            FahrgastrechteCard(journey: journey),
+            DepartureCard(journey: journey),
+            if (missed != null)
+              _MissedConnectionCard(
+                rescue: missed,
+                onPressed: () => _showMissedAlternatives(context, ref, missed),
+              ),
+            // The legs behind a swapped one are the OLD plan until the re-search
+            // lands — say so rather than let them read as checked (#55-Umstieg).
+            if (_replanning)
+              const MessageCard(
+                tone: MessageTone.info,
+                body: 'Anschlüsse werden für die neue Ankunft gesucht …',
+              ),
+            for (var i = 0; i < legs.length; i++) ...[
+              if (i > 0) _transfer(context, ref, legs[i - 1], legs[i]),
+              if (legs[i].isWalking)
+                _walkLeg(
+                  context,
+                  ref,
+                  legs[i],
                   i > 0 ? legs[i - 1] : null,
-                  i + 1 < legs.length ? legs[i + 1] : null)
-            else ...[
-              // Which section of the train you're ON to be in, so the change
-              // here is a step across the platform (#27). Sits right under the
-              // transfer tile — vendo models the change as a FUSSWEG leg, so
-              // that tile is the walk rendered at i-1. Self-hides unless both
-              // Wagenreihungen back it up.
-              Builder(builder: (_) {
-                final prev = _prevTransitLeg(legs, i);
-                if (prev == null) return const SizedBox.shrink();
-                return TransferCoachHint(
-                  key: ValueKey('coach-hint-${prev.tripId}-${legs[i].tripId}'),
-                  arriving: prev,
-                  departing: legs[i],
-                  samePlatform: journey.samePlatformTransferInto(legs[i]),
-                );
-              }),
-              if (legs[i].cancelled ||
-                  legs[i].partiallyCancelled ||
-                  legs[i].endsEarly)
-                _LegCancelBanner(leg: legs[i]),
-              _LegNotes(notes: _visibleNotes(legs[i].disruptions)),
-              Builder(builder: (_) {
-                final prev = _prevTransitLeg(legs, i);
-                final readyAt = prev != null ? _liveArrivalOf(prev) : null;
-                final gap = prev != null
-                    ? _gapMinutes(readyAt, _liveDepartureOf(legs[i]))
-                    : null;
-                return _LegSection(
-                  // NB no _refreshTick in the key: a pull-to-refresh must NOT
-                  // remount the section (that wipes its shown data); it flows
-                  // in as refreshTick and triggers an in-place silent re-fetch.
-                  key: ValueKey('leg-$i-${legs[i].tripId}'),
-                  refreshTick: _refreshTick,
-                  leg: legs[i],
-                  index: i,
-                  nextTransitLeg: _nextTransitLeg(legs, i),
-                  incomingGapMinutes: gap,
-                  readyAt: readyAt,
-                  transferStationName: prev?.destination.name,
-                  samePlatformTransfer: journey.samePlatformTransferInto(legs[i]),
-                  earlierAlight: _earlierAlightInput(legs, i, prev),
-                  // A fresh trip fetch carries live delays → recompute the
-                  // transfer windows above so a shrunk gap shows immediately.
-                  onTripUpdated: () {
-                    if (mounted) setState(() {});
+                  i + 1 < legs.length ? legs[i + 1] : null,
+                )
+              else ...[
+                // Which section of the train you're ON to be in, so the change
+                // here is a step across the platform (#27). Sits right under the
+                // transfer tile — vendo models the change as a FUSSWEG leg, so
+                // that tile is the walk rendered at i-1. Self-hides unless both
+                // Wagenreihungen back it up.
+                Builder(
+                  builder: (_) {
+                    final prev = _prevTransitLeg(legs, i);
+                    if (prev == null) return const SizedBox.shrink();
+                    return TransferCoachHint(
+                      key: ValueKey(
+                        'coach-hint-${prev.tripId}-${legs[i].tripId}',
+                      ),
+                      arriving: prev,
+                      departing: legs[i],
+                      samePlatform: journey.samePlatformTransferInto(legs[i]),
+                    );
                   },
-                  onReplaceLeg: _replaceLeg,
-                );
-              }),
+                ),
+                if (legs[i].cancelled ||
+                    legs[i].partiallyCancelled ||
+                    legs[i].endsEarly)
+                  _LegCancelBanner(leg: legs[i]),
+                _LegNotes(notes: _visibleNotes(legs[i].disruptions)),
+                Builder(
+                  builder: (_) {
+                    final prev = _prevTransitLeg(legs, i);
+                    final readyAt = prev != null ? _liveArrivalOf(prev) : null;
+                    final gap = prev != null
+                        ? _gapMinutes(readyAt, _liveDepartureOf(legs[i]))
+                        : null;
+                    return _LegSection(
+                      // NB no _refreshTick in the key: a pull-to-refresh must NOT
+                      // remount the section (that wipes its shown data); it flows
+                      // in as refreshTick and triggers an in-place silent re-fetch.
+                      key: ValueKey('leg-$i-${legs[i].tripId}'),
+                      refreshTick: _refreshTick,
+                      leg: legs[i],
+                      index: i,
+                      nextTransitLeg: _nextTransitLeg(legs, i),
+                      incomingGapMinutes: gap,
+                      readyAt: readyAt,
+                      transferStationName: prev?.destination.name,
+                      samePlatformTransfer: journey.samePlatformTransferInto(
+                        legs[i],
+                      ),
+                      earlierAlight: _earlierAlightInput(legs, i, prev),
+                      // A fresh trip fetch carries live delays → recompute the
+                      // transfer windows above so a shrunk gap shows immediately.
+                      onTripUpdated: () {
+                        if (mounted) setState(() {});
+                      },
+                      onReplaceLeg: _replaceLeg,
+                    );
+                  },
+                ),
+              ],
             ],
           ],
-        ],
         ),
       ),
     );
@@ -593,8 +627,11 @@ class _ConnectionDetailScreenState
   /// Mirror a bookmark toggle to the signed-in DB account's "Meine Reisen".
   /// No-op when logged out, or when the journey lacks a recon context /
   /// location ids (then it stays a purely local bookmark).
-  Future<void> _syncDbReise(WidgetRef ref, String key,
-      {required bool saved}) async {
+  Future<void> _syncDbReise(
+    WidgetRef ref,
+    String key, {
+    required bool saved,
+  }) async {
     if (!ref.read(dbAuthProvider).isLoggedIn) return;
     final service = ref.read(dbAccountServiceProvider);
     final ids = ref.read(dbSavedReiseIdsProvider.notifier);
@@ -608,8 +645,11 @@ class _ConnectionDetailScreenState
         final from = journey.origin?.locationId;
         final to = journey.destination?.locationId;
         final dep = journey.plannedDeparture ?? journey.departure;
-        if (kontext == null || !kontext.contains('¶') ||
-            from == null || to == null || dep == null) {
+        if (kontext == null ||
+            !kontext.contains('¶') ||
+            from == null ||
+            to == null ||
+            dep == null) {
           return; // not enough to create a DB trip — local bookmark only
         }
         final rkUuid = await service.saveReise(
@@ -629,7 +669,9 @@ class _ConnectionDetailScreenState
       // changed. It's also the wrong list — saved trips are reiseIndizes, not
       // bought orders.
       await ref.read(reisenuebersichtProvider.notifier).refresh();
-    } catch (_) {/* best-effort — the local bookmark already succeeded */}
+    } catch (_) {
+      /* best-effort — the local bookmark already succeeded */
+    }
   }
 
   /// Prominent "Kaufen" call to action. Opens the EXACT connection on bahn.de
@@ -654,7 +696,8 @@ class _ConnectionDetailScreenState
           icon: const Icon(Icons.shopping_cart_outlined),
           label: Text(label),
           style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 14)),
+            padding: const EdgeInsets.symmetric(vertical: 14),
+          ),
           onPressed: () => _openOnBahn(context, ref),
         ),
       ),
@@ -669,7 +712,9 @@ class _ConnectionDetailScreenState
     String? url;
     try {
       url = await ref.read(vendoServiceProvider).shareJourney(journey);
-    } catch (_) {/* fall back below */}
+    } catch (_) {
+      /* fall back below */
+    }
     url ??= _searchLink(ref);
     if (url == null) {
       messenger.showSnackBar(
@@ -688,7 +733,9 @@ class _ConnectionDetailScreenState
     String? link;
     try {
       link = await ref.read(vendoServiceProvider).shareJourney(journey);
-    } catch (_) {/* fall back below */}
+    } catch (_) {
+      /* fall back below */
+    }
     link ??= _searchLink(ref);
     if (link == null) {
       messenger.showSnackBar(
@@ -714,7 +761,9 @@ class _ConnectionDetailScreenState
     String? link;
     try {
       link = await ref.read(vendoServiceProvider).shareJourney(journey);
-    } catch (_) {/* fall back below */}
+    } catch (_) {
+      /* fall back below */
+    }
     link ??= _searchLink(ref);
     if (link == null) {
       messenger.showSnackBar(
@@ -763,9 +812,11 @@ class _ConnectionDetailScreenState
     final from = journey.origin;
     final to = journey.destination;
     if (from == null || to == null || from.id.isEmpty || to.id.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-        content: Text('Keine Alternativen — Start/Ziel unbekannt.'),
-      ));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Keine Alternativen — Start/Ziel unbekannt.'),
+        ),
+      );
       return;
     }
     final n = ref.read(journeySearchProvider.notifier);
@@ -793,10 +844,12 @@ class _ConnectionDetailScreenState
     final library = ref.read(libraryProvider.notifier);
     if (ref.read(libraryProvider).hasJourney(key)) {
       library.setJourneyWatched(key, false);
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-        duration: Duration(seconds: 4),
-        content: Text('Benachrichtigungen für diese Reise aus.'),
-      ));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          duration: Duration(seconds: 4),
+          content: Text('Benachrichtigungen für diese Reise aus.'),
+        ),
+      );
     }
     final n = ref.read(journeySearchProvider.notifier);
     n.setFrom(rescue.from);
@@ -823,12 +876,11 @@ class _ConnectionDetailScreenState
     }
     final chosen = hub ?? await _pickStopoverHub(context);
     if (chosen == null || !context.mounted) return;
-    ref.read(stopoverPlanProvider.notifier).start(StopoverPlanArgs(
-          from: from,
-          hub: chosen,
-          to: to,
-          deadline: deadline,
-        ));
+    ref
+        .read(stopoverPlanProvider.notifier)
+        .start(
+          StopoverPlanArgs(from: from, hub: chosen, to: to, deadline: deadline),
+        );
     context.push('/stopover-plan');
   }
 
@@ -875,9 +927,10 @@ class _ConnectionDetailScreenState
           children: [
             const Padding(
               padding: EdgeInsets.fromLTRB(20, 0, 20, 4),
-              child: Text('Wo willst du Zeit verbringen?',
-                  style:
-                      TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+              child: Text(
+                'Wo willst du Zeit verbringen?',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
             ),
             const Padding(
               padding: EdgeInsets.fromLTRB(20, 0, 20, 8),
@@ -889,12 +942,13 @@ class _ConnectionDetailScreenState
             ),
             for (final (i, station) in list.indexed)
               ListTile(
-                leading: Icon(i < transferCount
-                    ? Icons.swap_calls
-                    : Icons.pause_circle_outline),
+                leading: Icon(
+                  i < transferCount
+                      ? Icons.swap_calls
+                      : Icons.pause_circle_outline,
+                ),
                 title: Text(station.name),
-                subtitle:
-                    Text(i < transferCount ? 'Umstieg' : 'Zwischenhalt'),
+                subtitle: Text(i < transferCount ? 'Umstieg' : 'Zwischenhalt'),
                 onTap: () => Navigator.of(context).pop(station),
               ),
           ],
@@ -915,7 +969,8 @@ class _ConnectionDetailScreenState
     if (stops.length < 2) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-            content: Text('Zu wenige Haltestellen für ein Split-Ticket.')),
+          content: Text('Zu wenige Haltestellen für ein Split-Ticket.'),
+        ),
       );
       return;
     }
@@ -923,7 +978,9 @@ class _ConnectionDetailScreenState
     final dep = journey.plannedDeparture ?? journey.departure;
     final date = dep != null ? dep.toIso8601String().split('T').first : '';
 
-    ref.read(splitTicketProvider.notifier).analyze(
+    ref
+        .read(splitTicketProvider.notifier)
+        .analyze(
           stops: stops,
           date: date,
           directPrice: journey.price?.amount ?? 0,
@@ -931,7 +988,8 @@ class _ConnectionDetailScreenState
               '${journey.origin?.name ?? ''} → ${journey.destination?.name ?? ''}',
           // Stable per-connection key so re-opening the same connection resumes
           // the running analysis instead of restarting it.
-          jobKey: '${journey.origin?.id}-${journey.destination?.id}-'
+          jobKey:
+              '${journey.origin?.id}-${journey.destination?.id}-'
               '${(journey.plannedDeparture ?? journey.departure)?.toIso8601String()}',
         );
     context.push('/split-ticket', extra: journey);
@@ -957,20 +1015,24 @@ class _ConnectionDetailScreenState
     if (worst != null && worst <= 2) {
       final theme = Theme.of(context);
       final missed = worst < 0;
-      final color =
-          missed ? theme.colorScheme.error : const Color(0xFFCC8800);
+      final color = missed ? theme.colorScheme.error : const Color(0xFFCC8800);
       return Row(
         children: [
-          Icon(missed ? Icons.link_off : Icons.warning_amber_rounded,
-              size: 18, color: color),
+          Icon(
+            missed ? Icons.link_off : Icons.warning_amber_rounded,
+            size: 18,
+            color: color,
+          ),
           const SizedBox(width: 6),
           Expanded(
             child: Text(
               missed
                   ? 'Anschluss laut Live-Daten nicht erreichbar'
                   : 'Anschluss sehr knapp (${worst <= 0 ? 0 : worst} Min, live)',
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: color, fontWeight: FontWeight.w600),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],
@@ -995,8 +1057,9 @@ class _ConnectionDetailScreenState
     if (text == null) return const SizedBox.shrink();
     final theme = Theme.of(context);
     final urgent = journey.bike.reservationRequired;
-    final color =
-        urgent ? AppColors.warning : theme.colorScheme.onSurfaceVariant;
+    final color = urgent
+        ? AppColors.warning
+        : theme.colorScheme.onSurfaceVariant;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: Row(
@@ -1034,14 +1097,18 @@ class _ConnectionDetailScreenState
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: Row(
         children: [
-          Icon(Icons.history,
-              size: 16, color: theme.colorScheme.onSurfaceVariant),
+          Icon(
+            Icons.history,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           const SizedBox(width: 6),
           Expanded(
             child: Text(
               'Bei dir: ${seen.onTime} von ${seen.trips} Fahrten pünktlich',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ],
@@ -1075,8 +1142,9 @@ class _ConnectionDetailScreenState
                   child: Text(
                     '${journey.origin?.name ?? ''} → '
                     '${journey.destination?.name ?? ''}',
-                    style: theme.textTheme.titleLarge
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
               ],
@@ -1090,35 +1158,53 @@ class _ConnectionDetailScreenState
                   _summaryTime(context, 'ab', dep, depDelay),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 6),
-                    child: Icon(Icons.arrow_forward,
-                        size: 18, color: theme.colorScheme.onSurfaceVariant),
+                    child: Icon(
+                      Icons.arrow_forward,
+                      size: 18,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ],
                 if (arr != null) _summaryTime(context, 'an', arr, arrDelay),
                 const Spacer(),
                 if (journey.price != null)
-                  Text(journey.price!.formatted,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: theme.colorScheme.primary)),
+                  Text(
+                    journey.price!.formatted,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
               ],
             ),
             const SizedBox(height: 4),
             Row(
               children: [
-                Icon(Icons.schedule,
-                    size: 15, color: theme.colorScheme.onSurfaceVariant),
+                Icon(
+                  Icons.schedule,
+                  size: 15,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
                 const SizedBox(width: 4),
-                Text(journey.durationString,
-                    style: theme.textTheme.bodyMedium
-                        ?.copyWith(fontWeight: FontWeight.w600)),
+                Text(
+                  journey.durationString,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
                 const SizedBox(width: 12),
-                Icon(Icons.swap_calls,
-                    size: 15, color: theme.colorScheme.onSurfaceVariant),
+                Icon(
+                  Icons.swap_calls,
+                  size: 15,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
                 const SizedBox(width: 4),
-                Text(t == 0 ? 'Direkt' : '$t Umstieg${t > 1 ? 'e' : ''}',
-                    style: theme.textTheme.bodyMedium
-                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+                Text(
+                  t == 0 ? 'Direkt' : '$t Umstieg${t > 1 ? 'e' : ''}',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
               ],
             ),
             const SizedBox(height: 10),
@@ -1136,19 +1222,29 @@ class _ConnectionDetailScreenState
 
   /// "ab/an HH:MM" with a red "+N" when the leg endpoint is delayed.
   Widget _summaryTime(
-      BuildContext context, String label, DateTime time, int delaySec) {
+    BuildContext context,
+    String label,
+    DateTime time,
+    int delaySec,
+  ) {
     final theme = Theme.of(context);
     final mins = delaySec ~/ 60;
     return Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text('$label ',
-            style: theme.textTheme.bodySmall
-                ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
-        Text(time.hhmm,
-            style: theme.textTheme.titleLarge
-                ?.copyWith(fontWeight: FontWeight.bold)),
+        Text(
+          '$label ',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        Text(
+          time.hhmm,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
         // Delay as a clear pill (white on red/amber) next to *this* time — so a
         // late arrival shows behind the arrival time, not a tiny grey "+15".
         if (mins > 0)
@@ -1160,11 +1256,14 @@ class _ConnectionDetailScreenState
                 color: mins <= 5 ? Colors.orange.shade700 : Colors.red.shade700,
                 borderRadius: BorderRadius.circular(6),
               ),
-              child: Text('+$mins',
-                  style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 13,
-                      fontWeight: FontWeight.bold)),
+              child: Text(
+                '+$mins',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 13,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
             ),
           ),
       ],
@@ -1200,8 +1299,11 @@ class _ConnectionDetailScreenState
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.event_repeat,
-              size: 16, color: theme.colorScheme.onSurfaceVariant),
+          Icon(
+            Icons.event_repeat,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -1210,8 +1312,9 @@ class _ConnectionDetailScreenState
               // Sep" and a period with exceptions ("16. Jul bis 30. Okt;
               // nicht 22. Aug bis 4. Sep").
               'Verkehrstage dieser Verbindung: $note',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ],
@@ -1226,12 +1329,17 @@ class _ConnectionDetailScreenState
   /// the next train leaves from the platform you're standing on. 3 minutes is
   /// then genuinely enough, so the amber "knapp" hint would be noise — but a
   /// train you cannot physically reach (≤2 min) stays red either way.
-  (Color?, String?) _transferTone(BuildContext context, int? mins,
-      {bool samePlatform = false}) {
+  (Color?, String?) _transferTone(
+    BuildContext context,
+    int? mins, {
+    bool samePlatform = false,
+  }) {
     if (mins == null) return (null, null);
     if (mins <= 2) {
-      return (Theme.of(context).colorScheme.error,
-          'Anschluss evtl. nicht erreichbar');
+      return (
+        Theme.of(context).colorScheme.error,
+        'Anschluss evtl. nicht erreichbar',
+      );
     }
     if (mins <= 5 && !samePlatform) return (const Color(0xFFCC8800), null);
     return (null, null);
@@ -1246,10 +1354,7 @@ class _ConnectionDetailScreenState
   /// itself, so the tile stays at the plain "mit Fußweg" it had.
   String _walkDetail(JourneyLeg leg) {
     final parts = <String>[
-      if (leg.samePlatformTransfer)
-        'gleicher Bahnsteig'
-      else
-        'mit Fußweg',
+      if (leg.samePlatformTransfer) 'gleicher Bahnsteig' else 'mit Fußweg',
       if (leg.walkingDuration != null)
         '${leg.walkingDuration!.inMinutes} min Weg',
       if (leg.walkingDistance != null) '${leg.walkingDistance} m',
@@ -1348,7 +1453,8 @@ class _ConnectionDetailScreenState
   /// The planned Gleis this leg leaves from, when it differs from the live one
   /// — i.e. there was a Gleiswechsel and we can name what it used to be.
   String? _changedFromPlatform(JourneyLeg leg, String? live) {
-    final planned = _movedBay(leg)?.planned ??
+    final planned =
+        _movedBay(leg)?.planned ??
         leg.plannedDeparturePlatform ??
         leg.departurePlatform;
     if (live == null || planned == null || planned == live) return null;
@@ -1358,8 +1464,13 @@ class _ConnectionDetailScreenState
   /// A FUSSWEG leg between two trains. The headline number is the *time you
   /// have* to change (arrival → next departure), NOT how long the walk takes;
   /// the walk itself is shown as the secondary detail.
-  Widget _walkLeg(BuildContext context, WidgetRef ref, JourneyLeg leg,
-      JourneyLeg? prev, JourneyLeg? next) {
+  Widget _walkLeg(
+    BuildContext context,
+    WidgetRef ref,
+    JourneyLeg leg,
+    JourneyLeg? prev,
+    JourneyLeg? next,
+  ) {
     // Available transfer time: from the train's arrival to the next departure.
     // Use the freshest (live) times so a delay shrinks the window; strike the
     // scheduled value when it no longer holds. The leg's own
@@ -1378,8 +1489,11 @@ class _ConnectionDetailScreenState
     final planGap = _gapMinutes(planArr, planDep);
     final shown = liveGap ?? planGap;
     final changed = liveGap != null && planGap != null && liveGap != planGap;
-    final (color, warn) =
-        _transferTone(context, shown, samePlatform: leg.samePlatformTransfer);
+    final (color, warn) = _transferTone(
+      context,
+      shown,
+      samePlatform: leg.samePlatformTransfer,
+    );
 
     final head = shown != null ? '$shown min zum Umsteigen' : 'Umstieg';
     // Which Gleis you arrive on and which one you leave from — live, and
@@ -1396,20 +1510,17 @@ class _ConnectionDetailScreenState
     final movedBay = next != null ? _movedBay(next) : null;
     final gleise = (arrG != null || depG != null)
         ? '$word ${arrG ?? '?'} → $word ${depG ?? '?'}'
-            '${wasG != null ? _insteadOf(wasG, movedBay) : ''}'
+              '${wasG != null ? _insteadOf(wasG, movedBay) : ''}'
         : null;
     final detail = [?gleise, ?movedBay?.note, _walkDetail(leg)].join(' · ');
     // Vendo models nearly every transfer as this walking leg, so the step-free
     // check has to sit here too, not just on the direct-transfer path (#73).
     final liftWarn = _stepFreeWarning(ref, leg.origin.name, [arrG, depG]);
-    final warnText =
-        [?warn, ?liftWarn].join(' · ');
+    final warnText = [?warn, ?liftWarn].join(' · ');
 
     return _transferTile(
       context,
-      icon: leg.samePlatformTransfer
-          ? Icons.swap_horiz
-          : Icons.directions_walk,
+      icon: leg.samePlatformTransfer ? Icons.swap_horiz : Icons.directions_walk,
       head: head,
       strikeBefore: changed ? '$planGap min' : null,
       headColor: color,
@@ -1419,80 +1530,97 @@ class _ConnectionDetailScreenState
       onTap: leg.origin.name.isEmpty
           ? null
           : () => _openTransferMap(
-                context,
-                ref,
-                leg.origin,
-                // Live Gleise (#50) — see [_livePlatformAtArrival].
-                prev != null ? _livePlatformAtArrival(prev) : null,
-                next != null ? _livePlatformAtDeparture(next) : null,
-                // Einstieg (primary) = the departing/next train; Ausstieg
-                // (secondary) = the arriving/prev train — each drawn to scale.
-                // SCHEDULED times throughout: the Wagenreihung is keyed by
-                // service date, and a live time that has slipped past midnight
-                // asks for the next day's run (#32).
-                depRef: (next?.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: next!.line?.productName ?? '',
-                        trainNumber: next.line!.fahrtNr,
-                        time: next.plannedDeparture ?? next.departure,
-                      )
-                    : null,
-                arrRef: (prev?.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: prev!.line?.productName ?? '',
-                        trainNumber: prev.line!.fahrtNr,
-                        time: prev.plannedArrival ?? prev.arrival,
-                      )
-                    : null,
-                // ORIGIN refs → each train's real composition, fetched at its
-                // origin departure (a stop the sequence endpoint always serves).
-                depFallbackRef: (next?.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: next!.line?.productName ?? '',
-                        trainNumber: next.line!.fahrtNr,
-                        originEva: next.origin.id,
-                        departureTime: next.plannedDeparture ?? next.departure,
-                      )
-                    : null,
-                arrFallbackRef: (prev?.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: prev!.line?.productName ?? '',
-                        trainNumber: prev.line!.fahrtNr,
-                        originEva: prev.origin.id,
-                        departureTime: prev.plannedDeparture ?? prev.departure,
-                      )
-                    : null,
-                product: next?.line?.product, // Einstieg (primary)
-                secondaryProduct: prev?.line?.product, // Ausstieg (secondary)
-                primaryTypes: {
-                  ...primaryPoiTypesForProduct(prev?.line?.product),
-                  ...primaryPoiTypesForProduct(next?.line?.product),
-                },
-              ),
+              context,
+              ref,
+              leg.origin,
+              // Live Gleise (#50) — see [_livePlatformAtArrival].
+              prev != null ? _livePlatformAtArrival(prev) : null,
+              next != null ? _livePlatformAtDeparture(next) : null,
+              // Einstieg (primary) = the departing/next train; Ausstieg
+              // (secondary) = the arriving/prev train — each drawn to scale.
+              // SCHEDULED times throughout: the Wagenreihung is keyed by
+              // service date, and a live time that has slipped past midnight
+              // asks for the next day's run (#32).
+              depRef: (next?.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: next!.line?.productName ?? '',
+                      trainNumber: next.line!.fahrtNr,
+                      time: next.plannedDeparture ?? next.departure,
+                    )
+                  : null,
+              arrRef: (prev?.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: prev!.line?.productName ?? '',
+                      trainNumber: prev.line!.fahrtNr,
+                      time: prev.plannedArrival ?? prev.arrival,
+                    )
+                  : null,
+              // ORIGIN refs → each train's real composition, fetched at its
+              // origin departure (a stop the sequence endpoint always serves).
+              depFallbackRef: (next?.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: next!.line?.productName ?? '',
+                      trainNumber: next.line!.fahrtNr,
+                      originEva: next.origin.id,
+                      departureTime: next.plannedDeparture ?? next.departure,
+                    )
+                  : null,
+              arrFallbackRef: (prev?.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: prev!.line?.productName ?? '',
+                      trainNumber: prev.line!.fahrtNr,
+                      originEva: prev.origin.id,
+                      departureTime: prev.plannedDeparture ?? prev.departure,
+                    )
+                  : null,
+              product: next?.line?.product, // Einstieg (primary)
+              secondaryProduct: prev?.line?.product, // Ausstieg (secondary)
+              primaryTypes: {
+                ...primaryPoiTypesForProduct(prev?.line?.product),
+                ...primaryPoiTypesForProduct(next?.line?.product),
+              },
+            ),
     );
   }
 
   /// Open the platform-to-platform map straight away (no intermediate screen):
   /// Einstieg Gleis green, Ausstieg Gleis red, both with their section bands.
-  void _openTransferMap(BuildContext context, WidgetRef ref, Station station,
-      String? arrGleis, String? depGleis,
-      {({String category, String trainNumber, DateTime? time})? depRef,
-      ({String category, String trainNumber, DateTime? time})? arrRef,
-      ({String category, String trainNumber, String originEva, DateTime? departureTime})?
-          depFallbackRef,
-      ({String category, String trainNumber, String originEva, DateTime? departureTime})?
-          arrFallbackRef,
-      String? product,
-      String? secondaryProduct,
-      Set<String>? primaryTypes}) {
+  void _openTransferMap(
+    BuildContext context,
+    WidgetRef ref,
+    Station station,
+    String? arrGleis,
+    String? depGleis, {
+    ({String category, String trainNumber, DateTime? time})? depRef,
+    ({String category, String trainNumber, DateTime? time})? arrRef,
+    ({
+      String category,
+      String trainNumber,
+      String originEva,
+      DateTime? departureTime,
+    })?
+    depFallbackRef,
+    ({
+      String category,
+      String trainNumber,
+      String originEva,
+      DateTime? departureTime,
+    })?
+    arrFallbackRef,
+    String? product,
+    String? secondaryProduct,
+    Set<String>? primaryTypes,
+  }) {
     final note = (arrGleis != null && depGleis != null)
         ? 'Ausstieg Gleis $arrGleis · Einstieg Gleis $depGleis'
         : depGleis != null
-            ? 'Einstieg Gleis $depGleis'
-            : arrGleis != null
-                ? 'Ausstieg Gleis $arrGleis'
-                : 'Umstieg in ${station.name}';
-    ref.read(dedicatedStationMapProvider.notifier).loadForStation(
+        ? 'Einstieg Gleis $depGleis'
+        : arrGleis != null
+        ? 'Ausstieg Gleis $arrGleis'
+        : 'Umstieg in ${station.name}';
+    ref
+        .read(dedicatedStationMapProvider.notifier)
+        .loadForStation(
           station,
           highlightGleis: depGleis, // Einstieg — primary, green
           role: GleisRole.board,
@@ -1516,14 +1644,20 @@ class _ConnectionDetailScreenState
   }
 
   Widget _transfer(
-      BuildContext context, WidgetRef ref, JourneyLeg prev, JourneyLeg next) {
+    BuildContext context,
+    WidgetRef ref,
+    JourneyLeg prev,
+    JourneyLeg next,
+  ) {
     if (prev.isWalking || next.isWalking) return const SizedBox(height: 8);
     // Time you actually have to change trains (arrival → next departure), from
     // the freshest live data. When a delay has eaten into the scheduled gap we
     // strike the old number and show what's really left.
     final liveGap = _gapMinutes(_liveArrivalOf(prev), _liveDepartureOf(next));
-    final planGap = _gapMinutes(prev.plannedArrival ?? prev.arrival,
-        next.plannedDeparture ?? next.departure);
+    final planGap = _gapMinutes(
+      prev.plannedArrival ?? prev.arrival,
+      next.plannedDeparture ?? next.departure,
+    );
     final shown = liveGap ?? planGap;
     final changed = liveGap != null && planGap != null && liveGap != planGap;
 
@@ -1536,8 +1670,11 @@ class _ConnectionDetailScreenState
     // Vendo models every transfer as a FUSSWEG leg, so this path is for the
     // other sources; the flag rides on the arriving side there.
     final samePlatform = next.samePlatformTransfer;
-    final (color, warn) =
-        _transferTone(context, shown, samePlatform: samePlatform);
+    final (color, warn) = _transferTone(
+      context,
+      shown,
+      samePlatform: samePlatform,
+    );
 
     // "Gleis 4 → Gleis 5" reads like a hike; DB knows 4 and 5 are two sides of
     // one island platform and says so.
@@ -1545,16 +1682,15 @@ class _ConnectionDetailScreenState
     final movedInfo = _movedBay(next);
     final gleisText = (arrGleis != null || depGleis != null)
         ? '$word ${arrGleis ?? '?'} → $word ${depGleis ?? '?'}'
-            '${wasGleis != null ? _insteadOf(wasGleis, movedInfo) : ''}'
-            '${movedInfo?.note != null ? ' · ${movedInfo!.note}' : ''}'
-            '${samePlatform ? ' · gleicher Bahnsteig' : ''}'
+              '${wasGleis != null ? _insteadOf(wasGleis, movedInfo) : ''}'
+              '${movedInfo?.note != null ? ' · ${movedInfo!.note}' : ''}'
+              '${samePlatform ? ' · gleicher Bahnsteig' : ''}'
         : (samePlatform ? 'gleicher Bahnsteig' : null);
 
     // A lift that is out at exactly this transfer (#73) — only asked for by the
     // profiles that depend on one, and only ever additive: no data, no warning.
     final liftWarn = _stepFreeWarning(ref, station.name, [arrGleis, depGleis]);
-    final warnText =
-        [?warn, ?liftWarn].join(' · ');
+    final warnText = [?warn, ?liftWarn].join(' · ');
 
     return _transferTile(
       context,
@@ -1570,38 +1706,38 @@ class _ConnectionDetailScreenState
       onTap: station.name.isEmpty
           ? null
           : () => _openTransferMap(
-                context,
-                ref,
-                station,
-                arrGleis,
-                depGleis,
-                // ORIGIN refs → real per-car compositions for both trains,
-                // fetched at each train's origin so the Ausstieg train draws to
-                // scale even where this transfer stop's Wagenreihung 404s.
-                // Scheduled times: keyed by service date (#32).
-                depFallbackRef: (next.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: next.line?.productName ?? '',
-                        trainNumber: next.line!.fahrtNr,
-                        originEva: next.origin.id,
-                        departureTime: next.plannedDeparture ?? next.departure,
-                      )
-                    : null,
-                arrFallbackRef: (prev.line?.fahrtNr.isNotEmpty ?? false)
-                    ? (
-                        category: prev.line?.productName ?? '',
-                        trainNumber: prev.line!.fahrtNr,
-                        originEva: prev.origin.id,
-                        departureTime: prev.plannedDeparture ?? prev.departure,
-                      )
-                    : null,
-                product: next.line?.product, // Einstieg (primary)
-                secondaryProduct: prev.line?.product, // Ausstieg (secondary)
-                primaryTypes: {
-                  ...primaryPoiTypesForProduct(prev.line?.product),
-                  ...primaryPoiTypesForProduct(next.line?.product),
-                },
-              ),
+              context,
+              ref,
+              station,
+              arrGleis,
+              depGleis,
+              // ORIGIN refs → real per-car compositions for both trains,
+              // fetched at each train's origin so the Ausstieg train draws to
+              // scale even where this transfer stop's Wagenreihung 404s.
+              // Scheduled times: keyed by service date (#32).
+              depFallbackRef: (next.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: next.line?.productName ?? '',
+                      trainNumber: next.line!.fahrtNr,
+                      originEva: next.origin.id,
+                      departureTime: next.plannedDeparture ?? next.departure,
+                    )
+                  : null,
+              arrFallbackRef: (prev.line?.fahrtNr.isNotEmpty ?? false)
+                  ? (
+                      category: prev.line?.productName ?? '',
+                      trainNumber: prev.line!.fahrtNr,
+                      originEva: prev.origin.id,
+                      departureTime: prev.plannedDeparture ?? prev.departure,
+                    )
+                  : null,
+              product: next.line?.product, // Einstieg (primary)
+              secondaryProduct: prev.line?.product, // Ausstieg (secondary)
+              primaryTypes: {
+                ...primaryPoiTypesForProduct(prev.line?.product),
+                ...primaryPoiTypesForProduct(next.line?.product),
+              },
+            ),
     );
   }
 
@@ -1616,7 +1752,10 @@ class _ConnectionDetailScreenState
   /// facility data, this is null and the transfer reads exactly as before. It
   /// never *removes* a warning the timetable already earned.
   String? _stepFreeWarning(
-      WidgetRef ref, String stationName, List<String?> gleise) {
+    WidgetRef ref,
+    String stationName,
+    List<String?> gleise,
+  ) {
     const needsLift = {
       TransferProfile.accessible,
       TransferProfile.child,
@@ -1625,11 +1764,14 @@ class _ConnectionDetailScreenState
     final profile = ref.watch(settingsProvider).transferProfile;
     if (!needsLift.contains(profile) || stationName.isEmpty) return null;
 
-    final broken = ref
-            .watch(stepFreeTransferProvider((
-              station: stationName,
-              gleise: gleise.whereType<String>().join(','),
-            )))
+    final broken =
+        ref
+            .watch(
+              stepFreeTransferProvider((
+                station: stationName,
+                gleise: gleise.whereType<String>().join(','),
+              )),
+            )
             .asData
             ?.value ??
         const <StationFacility>[];
@@ -1667,8 +1809,11 @@ class _ConnectionDetailScreenState
           padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
           child: Row(
             children: [
-              Icon(icon,
-                  size: 18, color: headColor ?? theme.colorScheme.onSurfaceVariant),
+              Icon(
+                icon,
+                size: 18,
+                color: headColor ?? theme.colorScheme.onSurfaceVariant,
+              ),
               const SizedBox(width: 8),
               Expanded(
                 child: Column(
@@ -1702,23 +1847,32 @@ class _ConnectionDetailScreenState
                     if (detail != null)
                       Padding(
                         padding: const EdgeInsets.only(top: 2),
-                        child: Text(detail,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant)),
+                        child: Text(
+                          detail,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ),
                     if (warn != null)
                       Padding(
                         padding: const EdgeInsets.only(top: 2),
                         child: Row(
                           children: [
-                            Icon(Icons.warning_amber_rounded,
-                                size: 14, color: theme.colorScheme.error),
+                            Icon(
+                              Icons.warning_amber_rounded,
+                              size: 14,
+                              color: theme.colorScheme.error,
+                            ),
                             const SizedBox(width: 4),
                             Flexible(
-                              child: Text(warn,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                      color: theme.colorScheme.error,
-                                      fontWeight: FontWeight.w600)),
+                              child: Text(
+                                warn,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.error,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                             ),
                           ],
                         ),
@@ -1728,10 +1882,13 @@ class _ConnectionDetailScreenState
               ),
               if (onTap != null) ...[
                 const SizedBox(width: 8),
-                Icon(Icons.map_outlined,
-                    size: 18, color: theme.colorScheme.primary),
+                Icon(
+                  Icons.map_outlined,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
               ],
-              if (trailing != null) trailing,
+              ?trailing,
             ],
           ),
         ),
@@ -1875,7 +2032,8 @@ class _LegSectionState extends ConsumerState<_LegSection>
     final now = DateTime.now();
     DateTime? nextEvent;
     for (final so in trip.stopovers) {
-      final t = so.departure ??
+      final t =
+          so.departure ??
           so.plannedDeparture ??
           so.arrival ??
           so.plannedArrival;
@@ -1886,8 +2044,13 @@ class _LegSectionState extends ConsumerState<_LegSection>
     }
     if (nextEvent == null) return;
     var delay = nextEvent.difference(now) - const Duration(seconds: 60);
-    if (delay < const Duration(seconds: 30)) delay = const Duration(seconds: 30);
-    if (delay > const Duration(minutes: 10)) delay = const Duration(minutes: 10);
+    if (delay < const Duration(seconds: 30)) {
+      delay = const Duration(seconds: 30);
+    }
+
+    if (delay > const Duration(minutes: 10)) {
+      delay = const Duration(minutes: 10);
+    }
     _refreshTimer = Timer(delay, () {
       if (mounted) _fetchFresh(id, silent: true);
     });
@@ -1918,7 +2081,6 @@ class _LegSectionState extends ConsumerState<_LegSection>
   Future<void> _load() async {
     final id = widget.leg.tripId;
     if (id == null) {
-      if (mounted) setState(() => _loading = false);
       return;
     }
     // Serve cached data instantly, then refresh silently in the background.
@@ -1958,10 +2120,12 @@ class _LegSectionState extends ConsumerState<_LegSection>
         trip = trip.copyWith(line: trip.line.withName(label));
       }
       _tripCache[id] = trip;
-      if (mounted) setState(() {
-        _trip = trip;
-        _tripError = null;
-      });
+      if (mounted) {
+        setState(() {
+          _trip = trip;
+          _tripError = null;
+        });
+      }
       // Post-await (never during build) → safe to nudge the parent to recompute
       // transfer windows from the live arrival/departure this fetch just added.
       widget.onTripUpdated?.call();
@@ -1977,12 +2141,13 @@ class _LegSectionState extends ConsumerState<_LegSection>
         _coachCache[id] = cs;
         if (mounted) setState(() => _coach = cs);
       }
-    } catch (_) {/* optional */}
+    } catch (_) {
+      /* optional */
+    }
     if (mounted && !silent) setState(() => _loading = false);
     // Re-arm the stop-aligned refresh from the freshest trip we hold.
     if (mounted && _trip != null) _scheduleNextRefresh(_trip!);
   }
-
 
   void _openStopMap(Stopover stop) {
     if (stop.stop.name.isEmpty) return;
@@ -1992,10 +2157,14 @@ class _LegSectionState extends ConsumerState<_LegSection>
     // and the next stop on the run (the direction of travel — buses stop on the
     // right). See `pickPole` (#55).
     final stops = _trip?.stopovers ?? const <Stopover>[];
-    final here = stops.indexWhere((s) =>
-        (s.stop.id.isNotEmpty && s.stop.id == stop.stop.id) ||
-        s.stop.name == stop.stop.name);
-    final next = (here >= 0 && here + 1 < stops.length) ? stops[here + 1] : null;
+    final here = stops.indexWhere(
+      (s) =>
+          (s.stop.id.isNotEmpty && s.stop.id == stop.stop.id) ||
+          s.stop.name == stop.stop.name,
+    );
+    final next = (here >= 0 && here + 1 < stops.length)
+        ? stops[here + 1]
+        : null;
     final nextLat = next?.stop.latitude, nextLon = next?.stop.longitude;
 
     // On a wing train, when this is the stop you board at, narrow the map's
@@ -2006,7 +2175,7 @@ class _LegSectionState extends ConsumerState<_LegSection>
     final coach = _coach;
     final isLegBoarding =
         (stop.stop.id.isNotEmpty && stop.stop.id == leg.origin.id) ||
-            (stop.stop.name.isNotEmpty && stop.stop.name == leg.origin.name);
+        (stop.stop.name.isNotEmpty && stop.stop.name == leg.origin.name);
     // Where the RIDER gets off this leg — not the train's terminus. On an
     // intermediate boarding/alighting stop (Büchen for an ICE that starts in
     // Hamburg) the stopover's own isOrigin/isTerminus are both false, so the
@@ -2014,13 +2183,12 @@ class _LegSectionState extends ConsumerState<_LegSection>
     // truth for who boards/alights here. (#50-Karte)
     final isLegAlighting =
         (stop.stop.id.isNotEmpty && stop.stop.id == leg.destination.id) ||
-            (stop.stop.name.isNotEmpty &&
-                stop.stop.name == leg.destination.name);
+        (stop.stop.name.isNotEmpty && stop.stop.name == leg.destination.name);
     final gleisRole = isLegBoarding
         ? GleisRole.board
         : isLegAlighting
-            ? GleisRole.alight
-            : GleisRole.none;
+        ? GleisRole.alight
+        : GleisRole.none;
     if (coach != null && coach.splits && isLegBoarding) {
       final portion = coach.portionTo(leg.destination.name);
       final range = portion?.sectorRange;
@@ -2033,7 +2201,9 @@ class _LegSectionState extends ConsumerState<_LegSection>
       }
     }
 
-    ref.read(dedicatedStationMapProvider.notifier).loadForStation(
+    ref
+        .read(dedicatedStationMapProvider.notifier)
+        .loadForStation(
           stop.stop,
           highlightGleis: stop.platform,
           lineName: leg.line?.name.trim(),
@@ -2067,7 +2237,8 @@ class _LegSectionState extends ConsumerState<_LegSection>
           // Also hand the leg's ORIGIN ref so the map can fetch the composition
           // itself even when [coach] wasn't preloaded — the origin departure is
           // a stop the vehicle-sequence endpoint always serves.
-          fallbackRef: (leg.line?.fahrtNr != null && leg.line!.fahrtNr.isNotEmpty)
+          fallbackRef:
+              (leg.line?.fahrtNr != null && leg.line!.fahrtNr.isNotEmpty)
               ? (
                   category: leg.line?.productName ?? '',
                   trainNumber: leg.line!.fahrtNr,
@@ -2092,9 +2263,8 @@ class _LegSectionState extends ConsumerState<_LegSection>
       // Swipe/step control to cycle this segment's other departures and swap
       // the train in place. Only when a swap target exists (onReplaceLeg) and
       // it's a real train leg.
-      final switcher = (widget.onReplaceLeg != null &&
-              !leg.isWalking &&
-              leg.line != null)
+      final switcher =
+          (widget.onReplaceLeg != null && !leg.isWalking && leg.line != null)
           ? LegAlternativeSwitcher(
               key: _switcherKey,
               leg: leg,
@@ -2111,8 +2281,7 @@ class _LegSectionState extends ConsumerState<_LegSection>
         trip: trip,
         coach: _coach,
         onStopTap: _openStopMap,
-        boardingId:
-            leg.origin.id.isNotEmpty ? leg.origin.id : leg.origin.name,
+        boardingId: leg.origin.id.isNotEmpty ? leg.origin.id : leg.origin.name,
         alightingId: leg.destination.id.isNotEmpty
             ? leg.destination.id
             : leg.destination.name,
@@ -2122,8 +2291,9 @@ class _LegSectionState extends ConsumerState<_LegSection>
         predictionStrip: (!leg.isWalking && leg.line != null)
             ? LegPredictionBadge(leg: leg, nextLeg: widget.nextTransitLeg)
             : null,
-        legDestinationName:
-            leg.destination.name.isNotEmpty ? leg.destination.name : null,
+        legDestinationName: leg.destination.name.isNotEmpty
+            ? leg.destination.name
+            : null,
       );
       if (switcher == null) return detail;
       // The ENTIRE Fahrtblock is the swipe surface: grab anywhere on the block
@@ -2156,13 +2326,15 @@ class _LegSectionState extends ConsumerState<_LegSection>
               trip: degraded,
               coach: _coach,
               onStopTap: _openStopMap,
-              boardingId:
-                  leg.origin.id.isNotEmpty ? leg.origin.id : leg.origin.name,
+              boardingId: leg.origin.id.isNotEmpty
+                  ? leg.origin.id
+                  : leg.origin.name,
               alightingId: leg.destination.id.isNotEmpty
                   ? leg.destination.id
                   : leg.destination.name,
-              legDestinationName:
-                  leg.destination.name.isNotEmpty ? leg.destination.name : null,
+              legDestinationName: leg.destination.name.isNotEmpty
+                  ? leg.destination.name
+                  : null,
             ),
           ],
         );
@@ -2177,15 +2349,18 @@ class _LegSectionState extends ConsumerState<_LegSection>
       child: ListTile(
         leading: _loading
             ? const SizedBox(
-                width: 20, height: 20,
-                child: CircularProgressIndicator(strokeWidth: 2))
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
             : (line != null
-                ? ProductBadge(label: line.productBadge)
-                : const Icon(Icons.train)),
+                  ? ProductBadge(label: line.productBadge)
+                  : const Icon(Icons.train)),
         title: Text(line != null ? line.lineNumberWithFahrt : 'Zug'),
         subtitle: Text(
-            '${leg.origin.name} → ${leg.destination.name}'
-            '${leg.direction != null ? '  ·  Richtung ${leg.direction}' : ''}'),
+          '${leg.origin.name} → ${leg.destination.name}'
+          '${leg.direction != null ? '  ·  Richtung ${leg.direction}' : ''}',
+        ),
         trailing: (!_loading && _tripError != null)
             ? IconButton(
                 icon: const Icon(Icons.refresh),
@@ -2249,10 +2424,7 @@ class _MissedConnectionCard extends StatelessWidget {
   final MissedConnectionRescue rescue;
   final VoidCallback onPressed;
 
-  const _MissedConnectionCard({
-    required this.rescue,
-    required this.onPressed,
-  });
+  const _MissedConnectionCard({required this.rescue, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
@@ -2275,9 +2447,9 @@ class _MissedConnectionCard extends StatelessWidget {
                         ? 'Anschluss nicht geschafft?'
                         : 'Zug nicht geschafft?',
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w700,
-                          color: colors.onSecondaryContainer,
-                        ),
+                      fontWeight: FontWeight.w700,
+                      color: colors.onSecondaryContainer,
+                    ),
                   ),
                   const SizedBox(height: 2),
                   Text(
@@ -2288,10 +2460,7 @@ class _MissedConnectionCard extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
-            FilledButton(
-              onPressed: onPressed,
-              child: const Text('Verpasst'),
-            ),
+            FilledButton(onPressed: onPressed, child: const Text('Verpasst')),
           ],
         ),
       ),
@@ -2310,10 +2479,10 @@ class _JourneyCancelBanner extends StatelessWidget {
         : 'Diese Verbindung fällt aus';
     final body = partial
         ? 'Auf einem Abschnitt entfällt ein Halt. Prüfe die markierten '
-            'Halte und weiche bei Bedarf auf eine andere Abfahrt aus.'
+              'Halte und weiche bei Bedarf auf eine andere Abfahrt aus.'
         : 'Mindestens ein Zug dieser Verbindung fährt nicht. Wische über den '
-            'betroffenen Fahrtblock oder tippe „Weitere Abfahrten“, um auf '
-            'eine andere Abfahrt zu wechseln.';
+              'betroffenen Fahrtblock oder tippe „Weitere Abfahrten“, um auf '
+              'eine andere Abfahrt zu wechseln.';
     // One shared shape for every "the app is telling you something" block, so
     // a cancellation reads louder than a note by its tone, not by inventing its
     // own panel (#38).
@@ -2337,7 +2506,7 @@ class _LegCancelBanner extends StatelessWidget {
   static String? _hhmm(DateTime? t) => t == null
       ? null
       : ' um ${t.hour.toString().padLeft(2, '0')}:'
-          '${t.minute.toString().padLeft(2, '0')}';
+            '${t.minute.toString().padLeft(2, '0')}';
 
   @override
   Widget build(BuildContext context) {
@@ -2354,15 +2523,13 @@ class _LegCancelBanner extends StatelessWidget {
     final endsAt = leg.replacementDestination?.name;
     final label = endsAt != null
         ? '$line endet vorzeitig in $endsAt'
-            '${_hhmm(leg.replacementArrival) ?? ''}'
-            '${leg.replacementArrivalPlatform != null
-                ? ', Gleis ${leg.replacementArrivalPlatform}'
-                : ''}'
+              '${_hhmm(leg.replacementArrival) ?? ''}'
+              '${leg.replacementArrivalPlatform != null ? ', Gleis ${leg.replacementArrivalPlatform}' : ''}'
         : partial
-            ? (dropped.isEmpty
-                ? '$line: Halt entfällt'
-                : '$line: Halt entfällt – ${dropped.join(', ')}')
-            : '$line fällt aus';
+        ? (dropped.isEmpty
+              ? '$line: Halt entfällt'
+              : '$line: Halt entfällt – ${dropped.join(', ')}')
+        : '$line fällt aus';
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -2373,15 +2540,21 @@ class _LegCancelBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(partial ? Icons.warning_amber_rounded : Icons.cancel,
-              color: color, size: 18),
+          Icon(
+            partial ? Icons.warning_amber_rounded : Icons.cancel,
+            color: color,
+            size: 18,
+          ),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(label,
-                style: TextStyle(
-                    color: color,
-                    fontSize: 13.5,
-                    fontWeight: FontWeight.bold)),
+            child: Text(
+              label,
+              style: TextStyle(
+                color: color,
+                fontSize: 13.5,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ),
         ],
       ),
@@ -2433,12 +2606,17 @@ class _LegNotesState extends State<_LegNotes> {
                       _open
                           ? 'Hinweise ausblenden'
                           : '${notes.length} ${notes.length == 1 ? 'Hinweis' : 'Hinweise'}',
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(color: muted, fontWeight: FontWeight.w600),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: muted,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
-                  Icon(_open ? Icons.expand_less : Icons.expand_more,
-                      size: 18, color: muted),
+                  Icon(
+                    _open ? Icons.expand_less : Icons.expand_more,
+                    size: 18,
+                    color: muted,
+                  ),
                 ],
               ),
             ),
@@ -2458,9 +2636,12 @@ class _LegNotesState extends State<_LegNotes> {
                           Text('•', style: TextStyle(color: muted)),
                           const SizedBox(width: 8),
                           Expanded(
-                            child: Text(n,
-                                style: theme.textTheme.bodySmall
-                                    ?.copyWith(color: muted)),
+                            child: Text(
+                              n,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: muted,
+                              ),
+                            ),
                           ),
                         ],
                       ),

--- a/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
+++ b/flutter-app/lib/screens/connection_search/connection_detail_screen.dart
@@ -41,6 +41,7 @@ import '../../utils/split_stops.dart';
 import '../../utils/transfer_risk.dart';
 import '../../widgets/departure_card.dart';
 import '../../widgets/fahrgastrechte_card.dart';
+import '../../widgets/journey_reliability_card.dart';
 import '../../widgets/offline_package_bar.dart';
 import '../../widgets/prediction_badge.dart';
 import '../../widgets/product_badge.dart';
@@ -510,6 +511,7 @@ class _ConnectionDetailScreenState
           physics: const AlwaysScrollableScrollPhysics(),
           children: [
             _summary(context),
+            JourneyReliabilityCard(journey: journey),
             _ownExperience(context),
             _bikeNotice(context),
             // Offline, the legs below are replayed from this journey's package

--- a/flutter-app/lib/screens/departure_board/departure_board_screen.dart
+++ b/flutter-app/lib/screens/departure_board/departure_board_screen.dart
@@ -2,18 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/auto_refresh.dart';
+import '../../core/extensions.dart';
 import '../../models/departure.dart';
 import '../../providers/departure_board_provider.dart';
 import '../../providers/nearby_tab_provider.dart';
 import '../../providers/train_lookup_provider.dart';
-import '../../widgets/bahnhof_search_bar.dart';
+import '../../widgets/app_menu_button.dart';
 import '../../widgets/app_nav_bar.dart';
-import '../../widgets/station_search_field.dart';
+import '../../widgets/bahnhof_search_bar.dart';
 import '../../widgets/delay_badge.dart';
 import '../../widgets/platform_badge.dart';
-import '../../widgets/app_menu_button.dart';
-import '../../core/extensions.dart';
-import '../../core/auto_refresh.dart';
+import '../../widgets/station_search_field.dart';
 
 class DepartureBoardScreen extends ConsumerStatefulWidget {
   /// When embedded in the combined "Bahnhof" screen, drop our own AppBar — the
@@ -148,15 +148,22 @@ class _DepartureBoardScreenState extends ConsumerState<DepartureBoardScreen>
                     itemBuilder: (_) => [
                       const PopupMenuItem(value: null, child: Text('Alle')),
                       const PopupMenuItem(
-                          value: 'nationalExpress', child: Text('ICE')),
+                        value: 'nationalExpress',
+                        child: Text('ICE'),
+                      ),
                       const PopupMenuItem(
-                          value: 'national', child: Text('IC/EC')),
+                        value: 'national',
+                        child: Text('IC/EC'),
+                      ),
                       const PopupMenuItem(
-                          value: 'regionalExpress', child: Text('RE')),
+                        value: 'regionalExpress',
+                        child: Text('RE'),
+                      ),
+                      const PopupMenuItem(value: 'regional', child: Text('RB')),
                       const PopupMenuItem(
-                          value: 'regional', child: Text('RB')),
-                      const PopupMenuItem(
-                          value: 'suburban', child: Text('S-Bahn')),
+                        value: 'suburban',
+                        child: Text('S-Bahn'),
+                      ),
                     ],
                   ),
                 ],
@@ -170,13 +177,17 @@ class _DepartureBoardScreenState extends ConsumerState<DepartureBoardScreen>
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  Icon(Icons.sync,
-                      size: 13, color: theme.colorScheme.onSurfaceVariant),
+                  Icon(
+                    Icons.sync,
+                    size: 13,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                   const SizedBox(width: 4),
                   Text(
                     'Aktualisiert ${state.lastUpdated!.hhmm}',
-                    style: theme.textTheme.bodySmall
-                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ],
               ),
@@ -192,7 +203,10 @@ class _DepartureBoardScreenState extends ConsumerState<DepartureBoardScreen>
   }
 
   Widget _buildBoard(
-      BuildContext context, WidgetRef ref, DepartureBoardState state) {
+    BuildContext context,
+    WidgetRef ref,
+    DepartureBoardState state,
+  ) {
     if (state.station == null) {
       return const Center(
         child: Padding(
@@ -225,12 +239,14 @@ class _DepartureBoardScreenState extends ConsumerState<DepartureBoardScreen>
         // Clear the floating nav bar — it hovers over this list.
         padding: EdgeInsets.only(bottom: 32 + AppNavBar.insetOf(context)),
         itemCount: departures.length,
-        separatorBuilder: (_, __) => const Divider(height: 1, indent: 72),
+        separatorBuilder: (_, _) => const Divider(height: 1, indent: 72),
         itemBuilder: (context, index) {
           return _DepartureTile(
             departure: departures[index],
             onTap: () {
-              ref.read(trainLookupProvider.notifier).lookupByTripId(
+              ref
+                  .read(trainLookupProvider.notifier)
+                  .lookupByTripId(
                     departures[index].tripId,
                     lineLabel: departures[index].line.name,
                   );
@@ -276,13 +292,15 @@ class _DepartureTile extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.bold,
-                  decoration:
-                      departure.cancelled ? TextDecoration.lineThrough : null,
+                  decoration: departure.cancelled
+                      ? TextDecoration.lineThrough
+                      : null,
                 ),
               ),
               DelayBadge(
-                  delaySeconds: departure.delay,
-                  cancelled: departure.cancelled),
+                delaySeconds: departure.delay,
+                cancelled: departure.cancelled,
+              ),
             ],
           ),
         ),
@@ -297,8 +315,7 @@ class _DepartureTile extends StatelessWidget {
             ),
             child: Text(
               departure.line.displayName,
-              style: const TextStyle(
-                  fontSize: 12, fontWeight: FontWeight.bold),
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
             ),
           ),
           const SizedBox(width: 8),
@@ -324,8 +341,9 @@ class _DepartureTile extends StatelessWidget {
                 departure.remarks.first,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
-                    fontSize: 11,
-                    color: theme.colorScheme.onSurfaceVariant),
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ],

--- a/flutter-app/lib/screens/nearby/nearby_screen.dart
+++ b/flutter-app/lib/screens/nearby/nearby_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
+// import 'package:flutter/physics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/departure_board_provider.dart';
@@ -181,9 +181,6 @@ class _SnappyTabPhysics extends ScrollPhysics {
       _SnappyTabPhysics(parent: buildParent(ancestor));
 
   @override
-  SpringDescription get spring => SpringDescription.withDampingRatio(
-        mass: 0.5,
-        stiffness: 220,
-        ratio: 1.1,
-      );
+  SpringDescription get spring =>
+      SpringDescription.withDampingRatio(mass: 0.5, stiffness: 220, ratio: 1.1);
 }

--- a/flutter-app/lib/screens/settings/settings_screen.dart
+++ b/flutter-app/lib/screens/settings/settings_screen.dart
@@ -1,20 +1,19 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/backup.dart';
 import '../../core/constants.dart';
 import '../../core/offline_package.dart';
 import '../../models/reisende.dart';
 import '../../models/split_ticket.dart';
-import '../../models/transfer_profile.dart';
 import '../../models/traewelling_models.dart';
+import '../../models/transfer_profile.dart';
 import '../../providers/offline_package_provider.dart';
 import '../../providers/service_providers.dart';
 import '../../providers/settings_provider.dart';
@@ -33,9 +32,7 @@ class SettingsScreen extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Einstellungen'),
-      ),
+      appBar: AppBar(title: const Text('Einstellungen')),
       body: ListView(
         padding: const EdgeInsets.only(bottom: 32),
         children: [
@@ -53,18 +50,25 @@ class SettingsScreen extends ConsumerWidget {
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Icon(Icons.train,
-                        color: theme.colorScheme.onPrimaryContainer),
+                    child: Icon(
+                      Icons.train,
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(AppConstants.appName,
-                          style: theme.textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.bold)),
-                      Text('Version ${AppConstants.appVersion}',
-                          style: theme.textTheme.bodySmall),
+                      Text(
+                        AppConstants.appName,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        'Version ${AppConstants.appVersion}',
+                        style: theme.textTheme.bodySmall,
+                      ),
                     ],
                   ),
                 ],
@@ -82,8 +86,9 @@ class SettingsScreen extends ConsumerWidget {
                   secondary: const Icon(Icons.notifications_active_outlined),
                   title: const Text('Reise-Erinnerungen'),
                   subtitle: const Text(
-                      'Vor Abfahrt & Umstieg erinnern — offline geplant, '
-                      'für deine gespeicherten Reisen.'),
+                    'Vor Abfahrt & Umstieg erinnern — offline geplant, '
+                    'für deine gespeicherten Reisen.',
+                  ),
                   value: settings.remindersEnabled,
                   onChanged: (v) {
                     notifier.setRemindersEnabled(v);
@@ -100,10 +105,12 @@ class SettingsScreen extends ConsumerWidget {
                       value: settings.reminderLeadMinutes,
                       underline: const SizedBox.shrink(),
                       items: const [10, 15, 20, 30, 45, 60]
-                          .map((m) => DropdownMenuItem(
-                                value: m,
-                                child: Text('$m Min'),
-                              ))
+                          .map(
+                            (m) => DropdownMenuItem(
+                              value: m,
+                              child: Text('$m Min'),
+                            ),
+                          )
                           .toList(),
                       onChanged: (m) {
                         if (m != null) notifier.setReminderLeadMinutes(m);
@@ -115,7 +122,8 @@ class SettingsScreen extends ConsumerWidget {
                     secondary: const Icon(Icons.transfer_within_a_station),
                     title: const Text('Umstiegs-Hinweise'),
                     subtitle: const Text(
-                        'Kurz bevor dein Anschluss abfährt — mit Gleis & Übergang.'),
+                      'Kurz bevor dein Anschluss abfährt — mit Gleis & Übergang.',
+                    ),
                     value: settings.transferAlerts,
                     onChanged: (v) => notifier.setTransferAlerts(v),
                   ),
@@ -125,8 +133,9 @@ class SettingsScreen extends ConsumerWidget {
                   secondary: const Icon(Icons.pin_drop_outlined),
                   title: const Text('Ankunfts-Wecker'),
                   subtitle: const Text(
-                      '10 Min und 5 Min vor Ankunft erinnern (vibriert) — '
-                      'damit du deinen Halt nicht verschläfst.'),
+                    '10 Min und 5 Min vor Ankunft erinnern (vibriert) — '
+                    'damit du deinen Halt nicht verschläfst.',
+                  ),
                   value: settings.arrivalAlertEnabled,
                   onChanged: (v) {
                     notifier.setArrivalAlertEnabled(v);
@@ -140,8 +149,9 @@ class SettingsScreen extends ConsumerWidget {
                     secondary: const Icon(Icons.alarm),
                     title: const Text('Laut klingeln'),
                     subtitle: const Text(
-                        'Ankunfts- und GPS-Hinweis als echten Wecker klingeln '
-                        'lassen, bis du ihn stoppst.'),
+                      'Ankunfts- und GPS-Hinweis als echten Wecker klingeln '
+                      'lassen, bis du ihn stoppst.',
+                    ),
                     value: settings.arrivalAlarmSound,
                     onChanged: (v) {
                       notifier.setArrivalAlarmSound(v);
@@ -154,8 +164,9 @@ class SettingsScreen extends ConsumerWidget {
                   secondary: const Icon(Icons.my_location),
                   title: const Text('GPS-Ausstiegsalarm'),
                   subtitle: const Text(
-                      'Läuft im Hintergrund: warnt am Ziel und erkennt per '
-                      'Fahrplan + Position mögliche ungemeldete Verspätung.'),
+                    'Läuft im Hintergrund: warnt am Ziel und erkennt per '
+                    'Fahrplan + Position mögliche ungemeldete Verspätung.',
+                  ),
                   value: settings.exitAlarmEnabled,
                   onChanged: (v) async {
                     if (!v) {
@@ -175,19 +186,21 @@ class SettingsScreen extends ConsumerWidget {
                         if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(
-                              content: Text(
-                                  'Ohne Benachrichtigungen kann der Ausstiegsalarm '
-                                  'dich nicht warnen — bitte in den Systemeinstellungen '
-                                  'erlauben.')),
+                            content: Text(
+                              'Ohne Benachrichtigungen kann der Ausstiegsalarm '
+                              'dich nicht warnen — bitte in den Systemeinstellungen '
+                              'erlauben.',
+                            ),
+                          ),
                         );
                         return;
                       }
                       notifier.setExitAlarmEnabled(true);
                     } catch (e) {
                       if (!context.mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text(e.toString())),
-                      );
+                      ScaffoldMessenger.of(
+                        context,
+                      ).showSnackBar(SnackBar(content: Text(e.toString())));
                     }
                   },
                 ),
@@ -196,8 +209,9 @@ class SettingsScreen extends ConsumerWidget {
                   secondary: const Icon(Icons.tag),
                   title: const Text('Live-Chip: Stationen statt Zeit'),
                   subtitle: const Text(
-                      'Der kleine Status-Indikator (auch Samsung Now Bar) zeigt '
-                      'die Anzahl Halte bis zum Ausstieg statt der Restzeit.'),
+                    'Der kleine Status-Indikator (auch Samsung Now Bar) zeigt '
+                    'die Anzahl Halte bis zum Ausstieg statt der Restzeit.',
+                  ),
                   value: settings.liveChipStops,
                   onChanged: (v) => notifier.setLiveChipStops(v),
                 ),
@@ -206,9 +220,10 @@ class SettingsScreen extends ConsumerWidget {
                   leading: const Icon(Icons.directions_walk),
                   title: const Text('Umsteigeprofil'),
                   subtitle: Text(
-                      '${settings.transferProfile.emoji} '
-                      '${settings.transferProfile.label} — '
-                      '${settings.transferProfile.hint}'),
+                    '${settings.transferProfile.emoji} '
+                    '${settings.transferProfile.label} — '
+                    '${settings.transferProfile.hint}',
+                  ),
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => _pickTransferProfile(context, ref, settings),
                 ),
@@ -220,65 +235,76 @@ class SettingsScreen extends ConsumerWidget {
 
           // Träwelling login/account — moved here from the tab AppBars so it
           // lives in one place: log in/out and reach the hub from Settings.
-          Builder(builder: (context) {
-            final auth = ref.watch(traewellingAuthProvider);
-            final user = auth.user;
-            final loggedIn = user != null;
-            final hasPic = user?.profilePicture?.isNotEmpty ?? false;
-            return Card(
-              margin: const EdgeInsets.symmetric(horizontal: 16),
-              child: Column(
-                children: [
-                  ListTile(
-                    leading: hasPic
-                        ? CircleAvatar(
-                            radius: 16,
-                            backgroundImage: NetworkImage(user!.profilePicture!),
-                          )
-                        // Official Träwelling logo when not signed in.
-                        : const TraewellingLogo(size: 32),
-                    title: Text(loggedIn ? user.displayName : 'Träwelling'),
-                    subtitle: Text(loggedIn
-                        ? '@${user.username} · angemeldet'
-                        : 'Nicht angemeldet · zum Einloggen tippen'),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () => context.push('/trawelling'),
-                  ),
-                  // Check-in preferences only make sense once connected.
-                  if (loggedIn) ...[
-                    const Divider(height: 1),
-                    SwitchListTile(
-                      secondary: const Icon(Icons.bolt),
-                      title: const Text('Automatisch einchecken'),
-                      subtitle: const Text(
-                          'Ein Tipp auf das Träwelling-Symbol im Zug checkt '
-                          'sofort ein – ohne Nachfrage.'),
-                      value: settings.trwlAutoCheckin,
-                      onChanged: notifier.setTrwlAutoCheckin,
-                    ),
-                    const Divider(height: 1),
+          Builder(
+            builder: (context) {
+              final auth = ref.watch(traewellingAuthProvider);
+              final user = auth.user;
+              final loggedIn = user != null;
+              final hasPic = user?.profilePicture?.isNotEmpty ?? false;
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 16),
+                child: Column(
+                  children: [
                     ListTile(
-                      leading: const Icon(Icons.visibility_outlined),
-                      title: const Text('Sichtbarkeit'),
-                      subtitle: const Text('Standard für App-Check-ins'),
-                      trailing: DropdownButton<int>(
-                        value: settings.trwlVisibility,
-                        underline: const SizedBox(),
-                        onChanged: (v) => notifier.setTrwlVisibility(v!),
-                        items: TrwlVisibility.values
-                            .map((v) => DropdownMenuItem(
-                                  value: v.value,
-                                  child: Text(v.label,
-                                      style: const TextStyle(fontSize: 14)),
-                                ))
-                            .toList(),
+                      leading: hasPic
+                          ? CircleAvatar(
+                              radius: 16,
+                              backgroundImage: NetworkImage(
+                                user!.profilePicture!,
+                              ),
+                            )
+                          // Official Träwelling logo when not signed in.
+                          : const TraewellingLogo(size: 32),
+                      title: Text(loggedIn ? user.displayName : 'Träwelling'),
+                      subtitle: Text(
+                        loggedIn
+                            ? '@${user.username} · angemeldet'
+                            : 'Nicht angemeldet · zum Einloggen tippen',
                       ),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () => context.push('/trawelling'),
                     ),
+                    // Check-in preferences only make sense once connected.
+                    if (loggedIn) ...[
+                      const Divider(height: 1),
+                      SwitchListTile(
+                        secondary: const Icon(Icons.bolt),
+                        title: const Text('Automatisch einchecken'),
+                        subtitle: const Text(
+                          'Ein Tipp auf das Träwelling-Symbol im Zug checkt '
+                          'sofort ein – ohne Nachfrage.',
+                        ),
+                        value: settings.trwlAutoCheckin,
+                        onChanged: notifier.setTrwlAutoCheckin,
+                      ),
+                      const Divider(height: 1),
+                      ListTile(
+                        leading: const Icon(Icons.visibility_outlined),
+                        title: const Text('Sichtbarkeit'),
+                        subtitle: const Text('Standard für App-Check-ins'),
+                        trailing: DropdownButton<int>(
+                          value: settings.trwlVisibility,
+                          underline: const SizedBox(),
+                          onChanged: (v) => notifier.setTrwlVisibility(v!),
+                          items: TrwlVisibility.values
+                              .map(
+                                (v) => DropdownMenuItem(
+                                  value: v.value,
+                                  child: Text(
+                                    v.label,
+                                    style: const TextStyle(fontSize: 14),
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ),
+                    ],
                   ],
-                ],
-              ),
-            );
-          }),
+                ),
+              );
+            },
+          ),
 
           _sectionHeader(context, 'Profil'),
 
@@ -297,7 +323,10 @@ class SettingsScreen extends ConsumerWidget {
                     items: BahnCardType.values.map((bc) {
                       return DropdownMenuItem(
                         value: bc,
-                        child: Text(bc.label, style: const TextStyle(fontSize: 14)),
+                        child: Text(
+                          bc.label,
+                          style: const TextStyle(fontSize: 14),
+                        ),
                       );
                     }).toList(),
                   ),
@@ -305,31 +334,39 @@ class SettingsScreen extends ConsumerWidget {
                 const Divider(height: 1),
 
                 // Weitere Ermäßigungen (Halbtax, Vorteilscard, etc.)
-                Builder(builder: (context) {
-                  final primaryTraveler = settings.searchParty.travelers
-                      .firstWhere((t) => t.typ.isPerson,
-                          orElse: () => const Traveler(typ: TravelerType.erwachsener));
-                  return ListTile(
-                    leading: const Icon(Icons.discount_outlined),
-                    title: const Text('Weitere Ermäßigung'),
-                    subtitle: const Text('Halbtax, Vorteilscard, NL-40 etc.'),
-                    trailing: DropdownButton<Reduction>(
-                      value: primaryTraveler.weitere,
-                      underline: const SizedBox(),
-                      onChanged: (v) {
-                        if (v != null) {
-                          notifier.setWeitereReduction(v);
-                        }
-                      },
-                      items: Reduction.weitereOptions.map((r) {
-                        return DropdownMenuItem(
-                          value: r,
-                          child: Text(r.label, style: const TextStyle(fontSize: 14)),
+                Builder(
+                  builder: (context) {
+                    final primaryTraveler = settings.searchParty.travelers
+                        .firstWhere(
+                          (t) => t.typ.isPerson,
+                          orElse: () =>
+                              const Traveler(typ: TravelerType.erwachsener),
                         );
-                      }).toList(),
-                    ),
-                  );
-                }),
+                    return ListTile(
+                      leading: const Icon(Icons.discount_outlined),
+                      title: const Text('Weitere Ermäßigung'),
+                      subtitle: const Text('Halbtax, Vorteilscard, NL-40 etc.'),
+                      trailing: DropdownButton<Reduction>(
+                        value: primaryTraveler.weitere,
+                        underline: const SizedBox(),
+                        onChanged: (v) {
+                          if (v != null) {
+                            notifier.setWeitereReduction(v);
+                          }
+                        },
+                        items: Reduction.weitereOptions.map((r) {
+                          return DropdownMenuItem(
+                            value: r,
+                            child: Text(
+                              r.label,
+                              style: const TextStyle(fontSize: 14),
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    );
+                  },
+                ),
                 const Divider(height: 1),
 
                 // Deutschland-Ticket
@@ -352,7 +389,8 @@ class SettingsScreen extends ConsumerWidget {
               secondary: const Icon(Icons.subject),
               title: const Text('Einfache Sprache'),
               subtitle: const Text(
-                  'Störungshinweise in einfacheren Worten anzeigen'),
+                'Störungshinweise in einfacheren Worten anzeigen',
+              ),
               value: settings.plainLanguage,
               onChanged: (v) => notifier.setPlainLanguage(v),
             ),
@@ -519,7 +557,10 @@ class SettingsScreen extends ConsumerWidget {
   /// option needs its one-line "why", or the labels alone ("Normal" vs "Mehr
   /// Zeit") don't say what actually changes.
   void _pickTransferProfile(
-      BuildContext context, WidgetRef ref, AppSettings settings) {
+    BuildContext context,
+    WidgetRef ref,
+    AppSettings settings,
+  ) {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -530,8 +571,10 @@ class SettingsScreen extends ConsumerWidget {
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
-              child: Text('Umsteigeprofil',
-                  style: Theme.of(ctx).textTheme.titleLarge),
+              child: Text(
+                'Umsteigeprofil',
+                style: Theme.of(ctx).textTheme.titleLarge,
+              ),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
@@ -540,22 +583,29 @@ class SettingsScreen extends ConsumerWidget {
                 'Anschluss als knapp warnt — die Fahrplanzeiten selbst ändert '
                 'es nicht. Bleibt auf dem Gerät.',
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(ctx).colorScheme.onSurfaceVariant),
+                  color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
-            for (final p in TransferProfile.values)
-              RadioListTile<TransferProfile>(
-                value: p,
-                groupValue: settings.transferProfile,
-                title: Text('${p.emoji}  ${p.label}'),
-                subtitle: Text(p.hint),
-                onChanged: (v) {
-                  if (v != null) {
-                    ref.read(settingsProvider.notifier).setTransferProfile(v);
-                  }
-                  Navigator.pop(ctx);
-                },
+            RadioGroup<TransferProfile>(
+              groupValue: settings.transferProfile,
+              onChanged: (v) {
+                if (v != null) {
+                  ref.read(settingsProvider.notifier).setTransferProfile(v);
+                }
+                Navigator.pop(ctx);
+              },
+              child: Column(
+                children: [
+                  for (final p in TransferProfile.values)
+                    RadioListTile<TransferProfile>(
+                      value: p,
+                      title: Text('${p.emoji}  ${p.label}'),
+                      subtitle: Text(p.hint),
+                    ),
+                ],
               ),
+            ),
           ],
         ),
       ),
@@ -568,9 +618,9 @@ class SettingsScreen extends ConsumerWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: Theme.of(context).colorScheme.primary,
-              fontWeight: FontWeight.bold,
-            ),
+          color: Theme.of(context).colorScheme.primary,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
   }
@@ -599,10 +649,12 @@ class _OfflineStorageCard extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.offline_pin_outlined),
             title: const Text('Offline-Reisepakete'),
-            subtitle: Text(count == 0
-                ? 'Nichts gespeichert. In „Reisen" pro Reise speichern.'
-                : '$count ${count == 1 ? 'Reise' : 'Reisen'} · '
-                    '${offlineSizeLabel(bytes)}'),
+            subtitle: Text(
+              count == 0
+                  ? 'Nichts gespeichert. In „Reisen" pro Reise speichern.'
+                  : '$count ${count == 1 ? 'Reise' : 'Reisen'} · '
+                        '${offlineSizeLabel(bytes)}',
+            ),
             trailing: count == 0
                 ? null
                 : TextButton(
@@ -616,14 +668,19 @@ class _OfflineStorageCard extends ConsumerWidget {
   }
 
   Future<void> _confirmClear(
-      BuildContext context, WidgetRef ref, int count) async {
+    BuildContext context,
+    WidgetRef ref,
+    int count,
+  ) async {
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Alle Offline-Pakete löschen?'),
-        content: Text('$count gespeicherte ${count == 1 ? 'Reise' : 'Reisen'} '
-            'werden entfernt. Die Reisen selbst bleiben — nur die offline '
-            'verfügbaren Daten sind dann weg.'),
+        content: Text(
+          '$count gespeicherte ${count == 1 ? 'Reise' : 'Reisen'} '
+          'werden entfernt. Die Reisen selbst bleiben — nur die offline '
+          'verfügbaren Daten sind dann weg.',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
@@ -673,8 +730,10 @@ Future<String?> _askPassword(BuildContext context, {required bool confirm}) {
               ),
             if (error != null) ...[
               const SizedBox(height: 8),
-              Text(error!,
-                  style: TextStyle(color: Theme.of(ctx).colorScheme.error)),
+              Text(
+                error!,
+                style: TextStyle(color: Theme.of(ctx).colorScheme.error),
+              ),
             ],
             if (confirm) ...[
               const SizedBox(height: 12),
@@ -718,15 +777,15 @@ Future<void> _createBackup(BuildContext context) async {
   final messenger = ScaffoldMessenger.of(context);
   try {
     final file = await BackupService().writeBackup(password);
-    await SharePlus.instance.share(ShareParams(
-      files: [XFile(file.path)],
-      subject: 'Besser-Bahn Sicherung',
-    ));
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(file.path)], subject: 'Besser-Bahn Sicherung'),
+    );
   } on BackupError catch (e) {
     messenger.showSnackBar(SnackBar(content: Text(e.message)));
   } catch (e) {
     messenger.showSnackBar(
-        SnackBar(content: Text('Sicherung fehlgeschlagen: $e')));
+      SnackBar(content: Text('Sicherung fehlgeschlagen: $e')),
+    );
   }
 }
 
@@ -739,7 +798,8 @@ Future<void> _restoreBackup(BuildContext context) async {
   final picked = await FilePicker.platform.pickFiles(withData: true);
   final file = picked?.files.firstOrNull;
   if (file == null || !context.mounted) return;
-  final bytes = file.bytes ??
+  final bytes =
+      file.bytes ??
       (file.path != null ? await File(file.path!).readAsBytes() : null);
   if (bytes == null || !context.mounted) return;
 
@@ -748,16 +808,21 @@ Future<void> _restoreBackup(BuildContext context) async {
   final messenger = ScaffoldMessenger.of(context);
   try {
     final n = await BackupService().restore(bytes, password);
-    messenger.showSnackBar(SnackBar(
-      content: Text('$n Einträge wiederhergestellt — bitte die App neu '
-          'starten, damit alles geladen wird.'),
-      duration: const Duration(seconds: 6),
-    ));
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          '$n Einträge wiederhergestellt — bitte die App neu '
+          'starten, damit alles geladen wird.',
+        ),
+        duration: const Duration(seconds: 6),
+      ),
+    );
   } on BackupError catch (e) {
     messenger.showSnackBar(SnackBar(content: Text(e.message)));
   } catch (e) {
     messenger.showSnackBar(
-        SnackBar(content: Text('Wiederherstellen fehlgeschlagen: $e')));
+      SnackBar(content: Text('Wiederherstellen fehlgeschlagen: $e')),
+    );
   }
 }
 

--- a/flutter-app/lib/screens/train_lookup/train_lookup_screen.dart
+++ b/flutter-app/lib/screens/train_lookup/train_lookup_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:latlong2/latlong.dart';
 
+import '../../core/auto_refresh.dart';
+import '../../core/extensions.dart';
 import '../../models/library_models.dart';
 import '../../models/station.dart';
 import '../../models/trip.dart';
@@ -12,11 +14,9 @@ import '../../providers/library_provider.dart';
 import '../../providers/station_map_provider.dart';
 import '../../providers/train_lookup_provider.dart';
 import '../../services/hafas_service.dart';
-import '../../core/extensions.dart';
-import '../../core/auto_refresh.dart';
-import '../../widgets/bahnhof_search_bar.dart';
 import '../../widgets/app_menu_button.dart';
 import '../../widgets/app_nav_bar.dart';
+import '../../widgets/bahnhof_search_bar.dart';
 import '../../widgets/station_search_field.dart';
 import '../../widgets/traewelling_logo.dart';
 import '../../widgets/trwl_checkin_sheet.dart';
@@ -95,10 +95,9 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
     if (query.isEmpty) return;
     _searchedQuery = query;
     if (unfocus) _focusNode.unfocus();
-    ref.read(trainLookupProvider.notifier).lookupTrain(
-          query,
-          fromStationId: _fromStation?.id,
-        );
+    ref
+        .read(trainLookupProvider.notifier)
+        .lookupTrain(query, fromStationId: _fromStation?.id);
   }
 
   SavedTrain _savedTrainFor(TrainLookupState state) {
@@ -117,10 +116,9 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
     _controller.text = train.query;
     _searchedQuery = train.query;
     _focusNode.unfocus();
-    ref.read(trainLookupProvider.notifier).lookupTrain(
-          train.query,
-          fromStationId: train.fromStationId,
-        );
+    ref
+        .read(trainLookupProvider.notifier)
+        .lookupTrain(train.query, fromStationId: train.fromStationId);
   }
 
   @override
@@ -142,25 +140,29 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
     // rider's eye already is.
     final actions = <Widget>[
       if (state.trip != null)
-        Builder(builder: (context) {
-          final train = _savedTrainFor(state);
-          final saved = ref.watch(libraryProvider).hasTrain(train.key);
-          return IconButton(
-            visualDensity: VisualDensity.compact,
-            icon: Icon(saved ? Icons.star : Icons.star_border,
-                color: saved ? Colors.amber.shade700 : null),
-            tooltip: saved ? 'Zug entfernen' : 'Zug speichern',
-            onPressed: () {
-              ref.read(libraryProvider.notifier).toggleTrain(train);
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  duration: const Duration(seconds: 2),
-                  content: Text(saved ? 'Zug entfernt' : 'Zug gespeichert'),
-                ),
-              );
-            },
-          );
-        }),
+        Builder(
+          builder: (context) {
+            final train = _savedTrainFor(state);
+            final saved = ref.watch(libraryProvider).hasTrain(train.key);
+            return IconButton(
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                saved ? Icons.star : Icons.star_border,
+                color: saved ? Colors.amber.shade700 : null,
+              ),
+              tooltip: saved ? 'Zug entfernen' : 'Zug speichern',
+              onPressed: () {
+                ref.read(libraryProvider.notifier).toggleTrain(train);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    duration: const Duration(seconds: 2),
+                    content: Text(saved ? 'Zug entfernt' : 'Zug gespeichert'),
+                  ),
+                );
+              },
+            );
+          },
+        ),
       if (state.trip != null)
         IconButton(
           visualDensity: VisualDensity.compact,
@@ -199,17 +201,23 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                 border: InputBorder.none,
                 enabledBorder: InputBorder.none,
                 focusedBorder: InputBorder.none,
-                contentPadding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 8,
+                ),
                 hintText: 'z.B. ICE 148, RE 70, Bus 310',
                 prefixIcon: const Icon(Icons.train, size: 18),
-                prefixIconConstraints:
-                    const BoxConstraints(minWidth: 36, minHeight: 36),
+                prefixIconConstraints: const BoxConstraints(
+                  minWidth: 36,
+                  minHeight: 36,
+                ),
                 // Keep the suffix inside the dense field's height (an
                 // unconstrained IconButton is 48 px and taller than the field,
                 // which made the Zug search bar bigger than the other two).
-                suffixIconConstraints:
-                    const BoxConstraints(minWidth: 36, minHeight: 36),
+                suffixIconConstraints: const BoxConstraints(
+                  minWidth: 36,
+                  minHeight: 36,
+                ),
                 // The spinner takes the suffix while a lookup runs — with no
                 // search button left, this is the only place the field itself
                 // can say it is working.
@@ -241,13 +249,13 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                         },
                       ),
               ),
-                textInputAction: TextInputAction.search,
-                onChanged: _onQueryChanged,
-                // Still honoured, and it beats the debounce: a rider who
-                // hits Enter has said they are done typing.
-                onSubmitted: (_) => _search(),
-              ),
+              textInputAction: TextInputAction.search,
+              onChanged: _onQueryChanged,
+              // Still honoured, and it beats the debounce: a rider who
+              // hits Enter has said they are done typing.
+              onSubmitted: (_) => _search(),
             ),
+          ),
           // Optional station field for buses/trams
           if (_showStationField)
             Padding(
@@ -274,8 +282,11 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                       padding: const EdgeInsets.only(top: 4),
                       child: Row(
                         children: [
-                          Icon(Icons.check_circle, size: 14,
-                              color: theme.colorScheme.primary),
+                          Icon(
+                            Icons.check_circle,
+                            size: 14,
+                            color: theme.colorScheme.primary,
+                          ),
                           const SizedBox(width: 4),
                           Text(
                             _fromStation!.name,
@@ -297,9 +308,7 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
           const SizedBox(height: 8),
 
           // Content
-          Expanded(
-            child: _buildContent(context, state, theme),
-          ),
+          Expanded(child: _buildContent(context, state, theme)),
         ],
       ),
     );
@@ -314,7 +323,7 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
         itemCount: trains.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 8),
+        separatorBuilder: (_, _) => const SizedBox(width: 8),
         itemBuilder: (context, index) {
           final train = trains[index];
           return ActionChip(
@@ -328,7 +337,10 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
   }
 
   Widget _buildContent(
-      BuildContext context, TrainLookupState state, ThemeData theme) {
+    BuildContext context,
+    TrainLookupState state,
+    ThemeData theme,
+  ) {
     if (state.isLoading) {
       return const Center(
         child: Column(
@@ -349,12 +361,17 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.search_off, size: 48,
-                  color: theme.colorScheme.onSurfaceVariant),
+              Icon(
+                Icons.search_off,
+                size: 48,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               const SizedBox(height: 16),
-              Text(state.error!,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyLarge),
+              Text(
+                state.error!,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge,
+              ),
               if (_fromStation == null) ...[
                 const SizedBox(height: 12),
                 OutlinedButton.icon(
@@ -384,27 +401,33 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.train, size: 64,
-                  color: theme.colorScheme.onSurfaceVariant.withAlpha(80)),
+              Icon(
+                Icons.train,
+                size: 64,
+                color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
+              ),
               const SizedBox(height: 16),
               Text(
                 'Zugnummer eingeben',
                 style: theme.textTheme.titleMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant),
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
               const SizedBox(height: 8),
               Text(
                 'Live-Position, Verspätungen, Gleiswechsel\nund Wagenreihung auf einen Blick.',
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant),
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
               const SizedBox(height: 16),
               Text(
                 'Tipp: Für Busse & Tram tippe auf 📍 um eine Haltestelle anzugeben.',
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant),
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),
@@ -425,14 +448,16 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
             coach: state.coachSequence,
             onStopTap: (stop) {
               if (stop.stop.name.isEmpty) return;
-              ref.read(dedicatedStationMapProvider.notifier).loadForStation(
+              ref
+                  .read(dedicatedStationMapProvider.notifier)
+                  .loadForStation(
                     stop.stop,
                     highlightGleis: stop.platform,
                     role: stop.isTerminus
                         ? GleisRole.alight
                         : stop.isOrigin
-                            ? GleisRole.board
-                            : GleisRole.none,
+                        ? GleisRole.board
+                        : GleisRole.none,
                     // The map fetches this train's Wagenreihung for this stop,
                     // so the to-scale train shows at every stop.
                     coachRef: trip.line.fahrtNr.isNotEmpty
@@ -453,8 +478,7 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                         ? trip.direction.trim()
                         : null,
                     nextStopAt: _nextStopAt(trip, stop),
-                    primaryTypes:
-                        primaryPoiTypesForProduct(trip.line.product),
+                    primaryTypes: primaryPoiTypesForProduct(trip.line.product),
                   );
               // push (not go) → full-screen with a back button + swipe-back.
               context.push('/station-map');
@@ -469,17 +493,22 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
   /// what decides which side of the road a bus calls at (#55).
   LatLng? _nextStopAt(Trip trip, Stopover stop) {
     final stops = trip.stopovers;
-    final i = stops.indexWhere((s) =>
-        (s.stop.id.isNotEmpty && s.stop.id == stop.stop.id) ||
-        s.stop.name == stop.stop.name);
+    final i = stops.indexWhere(
+      (s) =>
+          (s.stop.id.isNotEmpty && s.stop.id == stop.stop.id) ||
+          s.stop.name == stop.stop.name,
+    );
     if (i < 0 || i + 1 >= stops.length) return null;
     final next = stops[i + 1].stop;
     final lat = next.latitude, lon = next.longitude;
     return (lat != null && lon != null) ? LatLng(lat, lon) : null;
   }
 
-  Widget _buildSearchResults(BuildContext context,
-      List<TrainSearchResult> results, ThemeData theme) {
+  Widget _buildSearchResults(
+    BuildContext context,
+    List<TrainSearchResult> results,
+    ThemeData theme,
+  ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -488,7 +517,8 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
           child: Text(
             '${results.length} Ergebnisse – bitte auswählen:',
             style: theme.textTheme.titleSmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant),
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
         Expanded(
@@ -501,7 +531,9 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                 child: ListTile(
                   leading: Container(
                     padding: const EdgeInsets.symmetric(
-                        horizontal: 8, vertical: 4),
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(6),
@@ -517,14 +549,17 @@ class _TrainLookupScreenState extends ConsumerState<TrainLookupScreen>
                       ),
                     ),
                   ),
-                  title: Text(result.lineName,
-                      style: const TextStyle(fontWeight: FontWeight.w600)),
+                  title: Text(
+                    result.lineName,
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
                   subtitle: Text('→ ${result.direction}'),
                   trailing: result.plannedWhen != null
                       ? Text(
                           result.plannedWhen!.hhmm,
-                          style: theme.textTheme.bodyLarge
-                              ?.copyWith(fontWeight: FontWeight.w500),
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            fontWeight: FontWeight.w500,
+                          ),
                         )
                       : null,
                   onTap: () {

--- a/flutter-app/lib/services/db_account_service.dart
+++ b/flutter-app/lib/services/db_account_service.dart
@@ -35,7 +35,7 @@ class DbAccountException implements Exception {
 /// are intentionally separate at DB.
 class DbBahnBonusAuthorizationRequired extends DbAccountException {
   const DbBahnBonusAuthorizationRequired()
-      : super('BahnBonus muss einmalig verknüpft werden', 403);
+    : super('BahnBonus muss einmalig verknüpft werden', 403);
 }
 
 /// Authenticated client for the signed-in user's DB account: profile,
@@ -52,19 +52,20 @@ class DbAccountService {
   /// [client] is injectable so tests can drive the real request path
   /// (coalescing, ETags, retries) against a mock transport.
   DbAccountService({FlutterSecureStorage? storage, http.Client? client})
-      : _client = client ?? http.Client(),
-        _storage = storage ??
-            const FlutterSecureStorage(
-              // On iOS, allow reads after the device has been unlocked once
-              // since boot — required so a token refresh fired by the app's
-              // resume path doesn't fail with "data is locked". On Android,
-              // flutter_secure_storage 10.x uses its own ciphers by default
-              // (the legacy EncryptedSharedPreferences flag is deprecated and
-              // ignored), so no aOptions needed.
-              iOptions: IOSOptions(
-                accessibility: KeychainAccessibility.first_unlock,
-              ),
-            );
+    : _client = client ?? http.Client(),
+      _storage =
+          storage ??
+          const FlutterSecureStorage(
+            // On iOS, allow reads after the device has been unlocked once
+            // since boot — required so a token refresh fired by the app's
+            // resume path doesn't fail with "data is locked". On Android,
+            // flutter_secure_storage 10.x uses its own ciphers by default
+            // (the legacy EncryptedSharedPreferences flag is deprecated and
+            // ignored), so no aOptions needed.
+            iOptions: IOSOptions(
+              accessibility: KeychainAccessibility.first_unlock,
+            ),
+          );
 
   final FlutterSecureStorage _storage;
   final http.Client _client;
@@ -195,7 +196,8 @@ class DbAccountService {
     final code = returned.queryParameters['code'];
     final returnedState = returned.queryParameters['state'];
     if (code == null) {
-      final err = returned.queryParameters['error_description'] ??
+      final err =
+          returned.queryParameters['error_description'] ??
           returned.queryParameters['error'] ??
           'Kein Autorisierungscode erhalten';
       throw DbAccountException(err);
@@ -213,17 +215,19 @@ class DbAccountService {
     String code,
     String verifier,
   ) async {
-    final res = await _client.post(
-      Uri.parse(DbAccountConstants.tokenUrl),
-      headers: {'Accept': 'application/json'},
-      body: {
-        'grant_type': 'authorization_code',
-        'client_id': DbAccountConstants.clientId,
-        'redirect_uri': DbAccountConstants.redirectUrl,
-        'code_verifier': verifier,
-        'code': code,
-      },
-    ).timeout(_timeout);
+    final res = await _client
+        .post(
+          Uri.parse(DbAccountConstants.tokenUrl),
+          headers: {'Accept': 'application/json'},
+          body: {
+            'grant_type': 'authorization_code',
+            'client_id': DbAccountConstants.clientId,
+            'redirect_uri': DbAccountConstants.redirectUrl,
+            'code_verifier': verifier,
+            'code': code,
+          },
+        )
+        .timeout(_timeout);
     if (res.statusCode != 200) {
       throw DbAccountException(
         'Anmeldung fehlgeschlagen: ${res.body}',
@@ -257,8 +261,9 @@ class DbAccountService {
   /// race: exactly one token rotation happens and all callers share its
   /// outcome.
   Future<_RefreshOutcome> _refresh() {
-    return _refreshInFlight ??=
-        _doRefresh().whenComplete(() => _refreshInFlight = null);
+    return _refreshInFlight ??= _doRefresh().whenComplete(
+      () => _refreshInFlight = null,
+    );
   }
 
   /// Outcome of a refresh attempt. `transient` means the request itself
@@ -274,15 +279,17 @@ class DbAccountService {
     }
     final http.Response res;
     try {
-      res = await _client.post(
-        Uri.parse(DbAccountConstants.tokenUrl),
-        headers: {'Accept': 'application/json'},
-        body: {
-          'grant_type': 'refresh_token',
-          'refresh_token': refresh,
-          'client_id': DbAccountConstants.clientId,
-        },
-      ).timeout(_timeout);
+      res = await _client
+          .post(
+            Uri.parse(DbAccountConstants.tokenUrl),
+            headers: {'Accept': 'application/json'},
+            body: {
+              'grant_type': 'refresh_token',
+              'refresh_token': refresh,
+              'client_id': DbAccountConstants.clientId,
+            },
+          )
+          .timeout(_timeout);
     } on TimeoutException {
       AppLog.log('refresh: timeout (transient)', tag: 'db-account');
       return _RefreshOutcome.transient;
@@ -391,15 +398,17 @@ class DbAccountService {
     final refresh = await _read(_kBahnBonusRefresh);
     if (refresh == null) return _RefreshOutcome.rejected;
     try {
-      final res = await _client.post(
-        Uri.parse(DbAccountConstants.tokenUrl),
-        headers: {'Accept': 'application/json'},
-        body: {
-          'grant_type': 'refresh_token',
-          'refresh_token': refresh,
-          'client_id': DbAccountConstants.bahnbonusOAuthClientId,
-        },
-      ).timeout(_timeout);
+      final res = await _client
+          .post(
+            Uri.parse(DbAccountConstants.tokenUrl),
+            headers: {'Accept': 'application/json'},
+            body: {
+              'grant_type': 'refresh_token',
+              'refresh_token': refresh,
+              'client_id': DbAccountConstants.bahnbonusOAuthClientId,
+            },
+          )
+          .timeout(_timeout);
       if (res.statusCode == 200) {
         await _storeBahnBonusTokens(
           json.decode(res.body) as Map<String, dynamic>,
@@ -450,36 +459,38 @@ class DbAccountService {
       );
     }
     if (code == null) {
-      final message = returned.queryParameters['error_description'] ??
+      final message =
+          returned.queryParameters['error_description'] ??
           returned.queryParameters['error'] ??
           'BahnBonus-Autorisierung abgebrochen';
       throw DbAccountException(message);
     }
-    final res = await _client.post(
-      Uri.parse(DbAccountConstants.tokenUrl),
-      headers: {'Accept': 'application/json'},
-      body: {
-        'grant_type': 'authorization_code',
-        'client_id': DbAccountConstants.bahnbonusOAuthClientId,
-        'redirect_uri': DbAccountConstants.bahnbonusRedirectUrl,
-        'code_verifier': verifier,
-        'code': code,
-      },
-    ).timeout(_timeout);
+    final res = await _client
+        .post(
+          Uri.parse(DbAccountConstants.tokenUrl),
+          headers: {'Accept': 'application/json'},
+          body: {
+            'grant_type': 'authorization_code',
+            'client_id': DbAccountConstants.bahnbonusOAuthClientId,
+            'redirect_uri': DbAccountConstants.bahnbonusRedirectUrl,
+            'code_verifier': verifier,
+            'code': code,
+          },
+        )
+        .timeout(_timeout);
     if (res.statusCode != 200) {
       throw DbAccountException(
         'BahnBonus-Autorisierung fehlgeschlagen',
         res.statusCode,
       );
     }
-    await _storeBahnBonusTokens(
-      json.decode(res.body) as Map<String, dynamic>,
-    );
+    await _storeBahnBonusTokens(json.decode(res.body) as Map<String, dynamic>);
   }
 
   Future<void> _ensureBahnBonusAccess({required bool connect}) async {
     await _loadBahnBonusTokens();
-    final stillValid = _bahnBonusAccessToken != null &&
+    final stillValid =
+        _bahnBonusAccessToken != null &&
         (_bahnBonusExpiresAt == null ||
             DateTime.now().isBefore(
               _bahnBonusExpiresAt!.subtract(const Duration(seconds: 20)),
@@ -488,9 +499,7 @@ class DbAccountService {
     final refresh = await _refreshBahnBonus();
     if (refresh == _RefreshOutcome.success) return;
     if (refresh == _RefreshOutcome.transient) {
-      throw const DbAccountException(
-        'BahnBonus ist temporär nicht erreichbar',
-      );
+      throw const DbAccountException('BahnBonus ist temporär nicht erreichbar');
     }
     if (!connect) throw const DbBahnBonusAuthorizationRequired();
     await _authorizeBahnBonus();
@@ -512,8 +521,10 @@ class DbAccountService {
     await _delete(_kCorrelationId);
     try {
       final prefs = await SharedPreferences.getInstance();
-      final keys =
-          prefs.getKeys().where((k) => k.startsWith(_kEtagPrefix)).toList();
+      final keys = prefs
+          .getKeys()
+          .where((k) => k.startsWith(_kEtagPrefix))
+          .toList();
       for (final k in keys) {
         await prefs.remove(k);
       }
@@ -530,8 +541,9 @@ class DbAccountService {
       if (parts.length < 2) return null;
       final payload = parts[1];
       final normalized = base64Url.normalize(payload);
-      final map = json.decode(utf8.decode(base64Url.decode(normalized)))
-          as Map<String, dynamic>;
+      final map =
+          json.decode(utf8.decode(base64Url.decode(normalized)))
+              as Map<String, dynamic>;
       return map['kundenkontoid'] as String? ?? map['kundenkontoId'] as String?;
     } catch (_) {
       return null;
@@ -565,19 +577,18 @@ class DbAccountService {
   /// level). Anything we leave off would mark our traffic as non-Navigator
   /// at the edge.
   Map<String, String> _headers(String media) => {
-        'Authorization': 'Bearer $_accessToken',
-        'Accept': media,
-        'Accept-Language': 'de',
-        'User-Agent': 'DBNavigator/Android/26.9.0',
-        'X-App-Version': '26.9.0',
-        'X-Correlation-ID': _correlationId ?? _uuid(),
-        // ignore: use_null_aware_elements — null-aware map entries don't
-        // allow nullable values yet (Dart 3.10), so keep the explicit if.
-        if (_deviceOsName != null) 'X-Device-OS-Name': _deviceOsName!,
-        if (_deviceOsVersion != null) 'X-Device-OS-Version': _deviceOsVersion!,
-        if (_deviceModel != null) 'X-Device-Model': _deviceModel!,
-        'X-Instana-Android': _uuid(),
-      };
+    'Authorization': 'Bearer $_accessToken',
+    'Accept': media,
+    'Accept-Language': 'de',
+    'User-Agent': 'DBNavigator/Android/26.9.0',
+    'X-App-Version': '26.9.0',
+    'X-Correlation-ID': _correlationId ?? _uuid(),
+
+    'X-Device-OS-Name': ?_deviceOsName,
+    'X-Device-OS-Version': ?_deviceOsVersion,
+    'X-Device-Model': ?_deviceModel,
+    'X-Instana-Android': _uuid(),
+  };
 
   /// Lazily reads the real device model + Android SDK level once per process
   /// and reuses the result. iOS/desktop/web fall through with `Android` /
@@ -667,23 +678,29 @@ class DbAccountService {
     bool bypassEtag = false,
   }) {
     if (method != 'GET') {
-      return _dispatch(method, url,
-          media: media,
-          body: body,
-          retryOn401: retryOn401,
-          extraHeaders: extraHeaders,
-          bypassEtag: bypassEtag);
+      return _dispatch(
+        method,
+        url,
+        media: media,
+        body: body,
+        retryOn401: retryOn401,
+        extraHeaders: extraHeaders,
+        bypassEtag: bypassEtag,
+      );
     }
     // Forced and conditional reads must not share: joining a conditional call
     // could answer a forced refresh with a 304.
     return _coalescer.run(
       'GET $url${bypassEtag ? ' !etag' : ''}',
-      () => _dispatch(method, url,
-          media: media,
-          body: body,
-          retryOn401: retryOn401,
-          extraHeaders: extraHeaders,
-          bypassEtag: bypassEtag),
+      () => _dispatch(
+        method,
+        url,
+        media: media,
+        body: body,
+        retryOn401: retryOn401,
+        extraHeaders: extraHeaders,
+        bypassEtag: bypassEtag,
+      ),
     );
   }
 
@@ -776,12 +793,15 @@ class DbAccountService {
         tag: 'db-account',
       );
       await Future.delayed(delay);
-      return _dispatch(method, url,
-          media: media,
-          body: body,
-          retryOn401: false,
-          extraHeaders: extraHeaders,
-          bypassEtag: bypassEtag);
+      return _dispatch(
+        method,
+        url,
+        media: media,
+        body: body,
+        retryOn401: false,
+        extraHeaders: extraHeaders,
+        bypassEtag: bypassEtag,
+      );
     }
 
     // DB's mob backend returns **403** (not 401) when the access token has
@@ -795,12 +815,15 @@ class DbAccountService {
       );
       final r = await _refresh();
       if (r == _RefreshOutcome.success) {
-        return _dispatch(method, url,
-            media: media,
-            body: body,
-            retryOn401: false,
-            extraHeaders: extraHeaders,
-            bypassEtag: bypassEtag);
+        return _dispatch(
+          method,
+          url,
+          media: media,
+          body: body,
+          retryOn401: false,
+          extraHeaders: extraHeaders,
+          bypassEtag: bypassEtag,
+        );
       }
       // Only wipe the stored tokens when Keycloak EXPLICITLY rejected the
       // refresh — the previous behaviour wiped them on any failure (incl. a
@@ -877,8 +900,12 @@ class DbAccountService {
     }
     final url = '${DbAccountConstants.mobBase}/kundenkonten/$id';
     return _coalescer.run('PROFILE $url', () async {
-      final res = await _dispatch('POST', url,
-          media: DbAccountConstants.profileMedia, body: const []);
+      final res = await _dispatch(
+        'POST',
+        url,
+        media: DbAccountConstants.profileMedia,
+        body: const [],
+      );
       final profile = DbProfile.fromJson(_decode(res, 'kundenkonto'));
       AppLog.log('profile ${profile.kundennummer}', tag: 'db-account');
       return profile;
@@ -893,8 +920,11 @@ class DbAccountService {
     final id = await _kontoId();
     if (id == null) return null;
     final res = await _send(
-        'GET', '${DbAccountConstants.mobBase}/kundenkonten/$id/bbStatus',
-        media: DbAccountConstants.bahnbonusMedia, bypassEtag: forceFresh);
+      'GET',
+      '${DbAccountConstants.mobBase}/kundenkonten/$id/bbStatus',
+      media: DbAccountConstants.bahnbonusMedia,
+      bypassEtag: forceFresh,
+    );
     if (res.statusCode == 404) return null;
     // 304 used to fall into _decode and throw "bbStatus HTTP 304" — an error
     // the UI then had to paper over with the cache. It's not an error.
@@ -914,14 +944,14 @@ class DbAccountService {
     final today = now ?? DateTime.now();
     final date = today.toIso8601String().split('T').first;
     final startDate = '${today.year.toString().padLeft(4, '0')}-01-01';
-    final uri =
-        Uri.parse('${DbAccountConstants.bahnbonusCo2Base}/statistics').replace(
-      queryParameters: {
-        'interval': 'YEARLY',
-        'startDate': startDate,
-        'endDate': date,
-      },
-    );
+    final uri = Uri.parse('${DbAccountConstants.bahnbonusCo2Base}/statistics')
+        .replace(
+          queryParameters: {
+            'interval': 'YEARLY',
+            'startDate': startDate,
+            'endDate': date,
+          },
+        );
     final res = await _sendBahnBonus(uri, connect: connect);
     if (res.statusCode == 304 || res.statusCode == 404) return null;
     return _parseCo2(res, today);
@@ -948,18 +978,20 @@ class DbAccountService {
   }) async {
     await _ensureDeviceInfo();
     await _ensureBahnBonusAccess(connect: connect);
-    final res = await _client.get(
-      uri,
-      headers: {
-        'Authorization': 'Bearer $_bahnBonusAccessToken',
-        'Accept': 'application/json',
-        'Accept-Language': 'de',
-        'DB-Client-Id': DbAccountConstants.bahnbonusClientId,
-        'DB-Api-Key': DbAccountConstants.bahnbonusApiKey,
-        'User-Agent':
-            'BahnBonus/3.6.3 Android/${_deviceOsVersion ?? 'unknown'}',
-      },
-    ).timeout(_timeout);
+    final res = await _client
+        .get(
+          uri,
+          headers: {
+            'Authorization': 'Bearer $_bahnBonusAccessToken',
+            'Accept': 'application/json',
+            'Accept-Language': 'de',
+            'DB-Client-Id': DbAccountConstants.bahnbonusClientId,
+            'DB-Api-Key': DbAccountConstants.bahnbonusApiKey,
+            'User-Agent':
+                'BahnBonus/3.6.3 Android/${_deviceOsVersion ?? 'unknown'}',
+          },
+        )
+        .timeout(_timeout);
     if ((res.statusCode == 401 || res.statusCode == 403) && retry) {
       final refresh = await _refreshBahnBonus();
       if (refresh == _RefreshOutcome.success) {
@@ -982,15 +1014,21 @@ class DbAccountService {
   /// context value: `login` on cold-start restore, `manual` on user-pulled
   /// refresh, `auto` on background revalidation. [forceFresh] skips the
   /// conditional header so a `manual` pull can't be answered 304.
-  Future<List<DbBahnCard>?> bahncards(
-      {String trigger = 'login', bool forceFresh = false}) async {
-    AppLog.log('bahncards: GET emobilebahncards trigger=$trigger…',
-        tag: 'db-account');
+  Future<List<DbBahnCard>?> bahncards({
+    String trigger = 'login',
+    bool forceFresh = false,
+  }) async {
+    AppLog.log(
+      'bahncards: GET emobilebahncards trigger=$trigger…',
+      tag: 'db-account',
+    );
     final res = await _send(
-        'GET', '${DbAccountConstants.mobBase}/emobilebahncards',
-        media: DbAccountConstants.bahncardsMedia,
-        extraHeaders: {'call-trigger': trigger},
-        bypassEtag: forceFresh);
+      'GET',
+      '${DbAccountConstants.mobBase}/emobilebahncards',
+      media: DbAccountConstants.bahncardsMedia,
+      extraHeaders: {'call-trigger': trigger},
+      bypassEtag: forceFresh,
+    );
     AppLog.log(
       'bahncards HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
       tag: 'db-account',
@@ -1031,20 +1069,28 @@ class DbAccountService {
   /// [parseReisenuebersicht]. Returns null on 304 Not Modified. [forceFresh]
   /// skips the conditional header — used by pull-to-refresh, and after we
   /// ourselves changed the account's trips (a 304 would hide our own write).
-  Future<Map<String, dynamic>?> reisenuebersichtJson(
-      {bool onlyCurrent = false, bool forceFresh = false}) async {
+  Future<Map<String, dynamic>?> reisenuebersichtJson({
+    bool onlyCurrent = false,
+    bool forceFresh = false,
+  }) async {
     final p = await profile();
     final profilId = p.kundenprofilId;
     if (profilId == null) {
       throw const DbAccountException('Kundenprofil-ID unbekannt');
     }
     final uri = Uri.parse('${DbAccountConstants.mobBase}/reisenuebersicht')
-        .replace(queryParameters: {
-      'kundenprofilId': profilId,
-      'nurAktuelleAuftraege': onlyCurrent.toString(),
-    });
-    final res = await _send('GET', uri.toString(),
-        media: DbAccountConstants.reisenMedia, bypassEtag: forceFresh);
+        .replace(
+          queryParameters: {
+            'kundenprofilId': profilId,
+            'nurAktuelleAuftraege': onlyCurrent.toString(),
+          },
+        );
+    final res = await _send(
+      'GET',
+      uri.toString(),
+      media: DbAccountConstants.reisenMedia,
+      bypassEtag: forceFresh,
+    );
     if (res.statusCode == 304) return null;
     return _decode(res, 'reisenuebersicht');
   }
@@ -1052,23 +1098,25 @@ class DbAccountService {
   /// Same parsing the live `reisenuebersicht()` method does, but on a JSON
   /// that may have come from disk-cache instead of a fresh response.
   static DbReisenUebersicht parseReisenuebersicht(Map<String, dynamic> data) {
-    final orders = (data['auftragsIndizes'] as List<dynamic>? ?? const [])
-        .whereType<Map<String, dynamic>>()
-        .map(DbReiseIndex.fromJson)
-        .toList()
-      ..sort(
-        (a, b) => (b.aenderungsDatum ?? DateTime(0)).compareTo(
-          a.aenderungsDatum ?? DateTime(0),
-        ),
-      );
-    final saved = (data['reiseIndizes'] as List<dynamic>? ?? const [])
-        .whereType<Map<String, dynamic>>()
-        .map(DbSavedReiseIndex.fromJson)
-        .toList()
-      ..sort(
-        (a, b) => (b.startDatum ?? b.aenderungsDatum ?? DateTime(0))
-            .compareTo(a.startDatum ?? a.aenderungsDatum ?? DateTime(0)),
-      );
+    final orders =
+        (data['auftragsIndizes'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(DbReiseIndex.fromJson)
+            .toList()
+          ..sort(
+            (a, b) => (b.aenderungsDatum ?? DateTime(0)).compareTo(
+              a.aenderungsDatum ?? DateTime(0),
+            ),
+          );
+    final saved =
+        (data['reiseIndizes'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(DbSavedReiseIndex.fromJson)
+            .toList()
+          ..sort(
+            (a, b) => (b.startDatum ?? b.aenderungsDatum ?? DateTime(0))
+                .compareTo(a.startDatum ?? a.aenderungsDatum ?? DateTime(0)),
+          );
     return DbReisenUebersicht(orders: orders, saved: saved);
   }
 
@@ -1151,7 +1199,8 @@ class DbAccountService {
     String auftragsnummer,
     String kundenwunschId,
   ) async {
-    final url = '${DbAccountConstants.mobBase}/auftrag/$auftragsnummer'
+    final url =
+        '${DbAccountConstants.mobBase}/auftrag/$auftragsnummer'
         '/kundenwunsch/$kundenwunschId';
     final res = await _send('GET', url, media: DbAccountConstants.auftragMedia);
     if (res.statusCode == 304) return null;

--- a/flutter-app/lib/services/regional_transit_service.dart
+++ b/flutter-app/lib/services/regional_transit_service.dart
@@ -54,7 +54,7 @@ typedef PlatformCorrection = ({
 /// answer the app shows exactly what it showed before.
 class RegionalTransitService {
   RegionalTransitService({http.Client? client})
-      : _client = client ?? http.Client();
+    : _client = client ?? http.Client();
 
   final http.Client _client;
 
@@ -104,8 +104,10 @@ class RegionalTransitService {
 
   static void _markDead(RegionalProfile p) {
     _deadUntil[p.id] = DateTime.now().add(_deadFor);
-    AppLog.log('${p.id} als tot markiert für ${_deadFor.inMinutes} min',
-        tag: 'regional');
+    AppLog.log(
+      '${p.id} als tot markiert für ${_deadFor.inMinutes} min',
+      tag: 'regional',
+    );
   }
 
   /// Clear the circuit breaker — the static dead-list survives between tests
@@ -139,7 +141,10 @@ class RegionalTransitService {
   final Map<String, Future<List<RegionalDeparture>>> _boardsInflight = {};
 
   Future<Map<String, dynamic>?> _call(
-      RegionalProfile profile, String method, Map<String, dynamic> req) async {
+    RegionalProfile profile,
+    String method,
+    Map<String, dynamic> req,
+  ) async {
     final body = {
       'lang': 'de',
       'svcReqL': [
@@ -167,8 +172,10 @@ class RegionalTransitService {
           )
           .timeout(_timeout);
       if (res.statusCode != 200) {
-        AppLog.log('${profile.id} $method HTTP ${res.statusCode}',
-            tag: 'regional');
+        AppLog.log(
+          '${profile.id} $method HTTP ${res.statusCode}',
+          tag: 'regional',
+        );
         // A 5xx / gateway error is the endpoint being down, not this one call
         // being wrong — take it out of rotation so the next leg is instant.
         if (res.statusCode >= 500) _markDead(profile);
@@ -178,8 +185,10 @@ class RegionalTransitService {
           json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
       final svc = (data['svcResL'] as List<dynamic>?)?.firstOrNull;
       if (svc is! Map<String, dynamic> || svc['err'] != 'OK') {
-        AppLog.log('${profile.id} $method err ${svc is Map ? svc['err'] : '?'}',
-            tag: 'regional');
+        AppLog.log(
+          '${profile.id} $method err ${svc is Map ? svc['err'] : '?'}',
+          tag: 'regional',
+        );
         return null;
       }
       return svc['res'] as Map<String, dynamic>?;
@@ -204,7 +213,10 @@ class RegionalTransitService {
   }
 
   Future<String?> _resolveLocation(
-      RegionalProfile profile, String key, Station stop) async {
+    RegionalProfile profile,
+    String key,
+    Station stop,
+  ) async {
     final res = await _call(profile, 'LocMatch', {
       'input': {
         'loc': {'type': 'S', 'name': '${stop.name}?'},
@@ -212,8 +224,8 @@ class RegionalTransitService {
         'field': 'S',
       },
     });
-    final locs = ((res?['match'] as Map<String, dynamic>?)?['locL']
-            as List<dynamic>?) ??
+    final locs =
+        ((res?['match'] as Map<String, dynamic>?)?['locL'] as List<dynamic>?) ??
         const [];
     String? best;
     double bestMetres = double.infinity;
@@ -234,9 +246,10 @@ class RegionalTransitService {
     // 300 m: the same stop as seen by two datasets, never the next one along.
     final resolved = bestMetres <= 300 ? best : null;
     AppLog.log(
-        '${profile.id} loc "${stop.name}" → ${resolved ?? 'kein Treffer'}'
-        '${resolved != null ? ' (${bestMetres.round()} m)' : ''}',
-        tag: 'regional');
+      '${profile.id} loc "${stop.name}" → ${resolved ?? 'kein Treffer'}'
+      '${resolved != null ? ' (${bestMetres.round()} m)' : ''}',
+      tag: 'regional',
+    );
     _locations[key] = resolved;
     _locationsInflight.remove(key);
     return resolved;
@@ -255,7 +268,10 @@ class RegionalTransitService {
   }
 
   Future<String?> _resolveEfaStop(
-      RegionalProfile profile, String key, Station stop) async {
+    RegionalProfile profile,
+    String key,
+    Station stop,
+  ) async {
     final data = await _efaGet(profile, 'XML_STOPFINDER_REQUEST', {
       'name_sf': stop.name,
       'type_sf': 'any',
@@ -282,29 +298,43 @@ class RegionalTransitService {
         }
       }
       // No coordinate: only acceptable if nothing better turns up.
-      if (best == null) best = id;
+      best ??= id;
     }
     final resolved = (bestMetres <= 300 || bestMetres == double.infinity)
         ? best
         : null;
-    AppLog.log('${profile.id} efa stop "${stop.name}" → ${resolved ?? 'nichts'}',
-        tag: 'regional');
+    AppLog.log(
+      '${profile.id} efa stop "${stop.name}" → ${resolved ?? 'nichts'}',
+      tag: 'regional',
+    );
     _locations[key] = resolved;
     _locationsInflight.remove(key);
     return resolved;
   }
 
   Future<List<RegionalDeparture>> _efaBoard(
-      RegionalProfile profile, String stopId, DateTime around) {
+    RegionalProfile profile,
+    String stopId,
+    DateTime around,
+  ) {
     final bucket = around.millisecondsSinceEpoch ~/ (15 * 60 * 1000);
     final key = '${profile.id}/$stopId@$bucket';
     final cached = _boards[key];
     if (cached != null) return Future.value(cached);
-    return _boardsInflight[key] ??= _fetchEfaBoard(profile, key, stopId, around);
+    return _boardsInflight[key] ??= _fetchEfaBoard(
+      profile,
+      key,
+      stopId,
+      around,
+    );
   }
 
-  Future<List<RegionalDeparture>> _fetchEfaBoard(RegionalProfile profile,
-      String key, String stopId, DateTime around) async {
+  Future<List<RegionalDeparture>> _fetchEfaBoard(
+    RegionalProfile profile,
+    String key,
+    String stopId,
+    DateTime around,
+  ) async {
     final from = around.subtract(const Duration(minutes: 5));
     final data = await _efaGet(profile, 'XML_DM_REQUEST', {
       'name_dm': stopId,
@@ -316,15 +346,21 @@ class RegionalTransitService {
       'itdTime': '${_two(from.hour)}${_two(from.minute)}',
     });
     final list = parseEfaBoard(data);
-    AppLog.log('${profile.id} efa board $stopId: ${list.length} departures, '
-        '${list.where((d) => d.moved).length} moved', tag: 'regional');
+    AppLog.log(
+      '${profile.id} efa board $stopId: ${list.length} departures, '
+      '${list.where((d) => d.moved).length} moved',
+      tag: 'regional',
+    );
     _boards[key] = list;
     _boardsInflight.remove(key);
     return list;
   }
 
   Future<Map<String, dynamic>?> _efaGet(
-      RegionalProfile profile, String path, Map<String, String> params) async {
+    RegionalProfile profile,
+    String path,
+    Map<String, String> params,
+  ) async {
     final uri = Uri.parse('${profile.endpoint}/$path').replace(
       queryParameters: {
         'outputFormat': 'rapidJSON',
@@ -333,12 +369,20 @@ class RegionalTransitService {
       },
     );
     try {
-      final res = await _client.get(uri, headers: const {
-        'Accept': 'application/json',
-        'User-Agent': _userAgent,
-      }).timeout(_timeout);
+      final res = await _client
+          .get(
+            uri,
+            headers: const {
+              'Accept': 'application/json',
+              'User-Agent': _userAgent,
+            },
+          )
+          .timeout(_timeout);
       if (res.statusCode != 200) {
-        AppLog.log('${profile.id} $path HTTP ${res.statusCode}', tag: 'regional');
+        AppLog.log(
+          '${profile.id} $path HTTP ${res.statusCode}',
+          tag: 'regional',
+        );
         if (res.statusCode >= 500) _markDead(profile);
         return null;
       }
@@ -363,22 +407,27 @@ class RegionalTransitService {
       final transport = e['transportation'];
       final t = transport is Map<String, dynamic> ? transport : const {};
       final dest = t['destination'];
-      final planned = DateTime.tryParse(e['departureTimePlanned'] as String? ?? '');
-      out.add(RegionalDeparture(
-        line: ((t['number'] ?? t['name']) as String? ?? '').trim(),
-        direction: (dest is Map<String, dynamic>
-                ? dest['name'] as String? ?? ''
-                : '')
-            .trim(),
-        // EFA timestamps are UTC ("…Z"); the board is matched in local time.
-        plannedTime: planned == null
-            ? null
-            : planned.toLocal().hour * 60 + planned.toLocal().minute,
-        plannedPlatform: _efaText(p['plannedPlatformName']) ??
-            _efaText(p['platformName']),
-        livePlatform: _efaText(p['platformName']) ?? _efaText(p['platform']),
-        notes: _efaNotes(e['infos']),
-      ));
+      final planned = DateTime.tryParse(
+        e['departureTimePlanned'] as String? ?? '',
+      );
+      out.add(
+        RegionalDeparture(
+          line: ((t['number'] ?? t['name']) as String? ?? '').trim(),
+          direction:
+              (dest is Map<String, dynamic>
+                      ? dest['name'] as String? ?? ''
+                      : '')
+                  .trim(),
+          // EFA timestamps are UTC ("…Z"); the board is matched in local time.
+          plannedTime: planned == null
+              ? null
+              : planned.toLocal().hour * 60 + planned.toLocal().minute,
+          plannedPlatform:
+              _efaText(p['plannedPlatformName']) ?? _efaText(p['platformName']),
+          livePlatform: _efaText(p['platformName']) ?? _efaText(p['platform']),
+          notes: _efaNotes(e['infos']),
+        ),
+      );
     }
     return out;
   }
@@ -394,7 +443,8 @@ class RegionalTransitService {
     if (infos is! List) return const [];
     final out = <String>[];
     for (final i in infos.whereType<Map<String, dynamic>>()) {
-      final head = _efaText(i['subtitle']) ??
+      final head =
+          _efaText(i['subtitle']) ??
           _efaText(i['title']) ??
           _efaText(i['content']);
       if (head == null || out.contains(head)) continue;
@@ -406,7 +456,10 @@ class RegionalTransitService {
 
   /// The departure board at [extId] around [around].
   Future<List<RegionalDeparture>> _board(
-      RegionalProfile profile, String extId, DateTime around) {
+    RegionalProfile profile,
+    String extId,
+    DateTime around,
+  ) {
     final bucket = around.millisecondsSinceEpoch ~/ (15 * 60 * 1000);
     final key = '${profile.id}/$extId@$bucket';
     final cached = _boards[key];
@@ -415,7 +468,11 @@ class RegionalTransitService {
   }
 
   Future<List<RegionalDeparture>> _fetchBoard(
-      RegionalProfile profile, String key, String extId, DateTime around) async {
+    RegionalProfile profile,
+    String key,
+    String extId,
+    DateTime around,
+  ) async {
     // Start the board a few minutes early so a bus running late is still on it.
     final from = around.subtract(const Duration(minutes: 5));
     final res = await _call(profile, 'StationBoard', {
@@ -426,8 +483,11 @@ class RegionalTransitService {
       'maxJny': 80,
     });
     final list = parseBoard(res);
-    AppLog.log('${profile.id} board $extId: ${list.length} departures, '
-        '${list.where((d) => d.moved).length} moved', tag: 'regional');
+    AppLog.log(
+      '${profile.id} board $extId: ${list.length} departures, '
+      '${list.where((d) => d.moved).length} moved',
+      tag: 'regional',
+    );
     _boards[key] = list;
     _boardsInflight.remove(key);
     return list;
@@ -443,22 +503,25 @@ class RegionalTransitService {
     final himL = himRaw is List<dynamic> ? himRaw : const [];
     final jnyRaw = res['jnyL'];
     final out = <RegionalDeparture>[];
-    for (final j in (jnyRaw is List<dynamic> ? jnyRaw : const [])
-        .whereType<Map<String, dynamic>>()) {
+    for (final j
+        in (jnyRaw is List<dynamic> ? jnyRaw : const [])
+            .whereType<Map<String, dynamic>>()) {
       final stop = j['stbStop'] as Map<String, dynamic>?;
       if (stop == null) continue;
       final prodX = j['prodX'];
       final prod = (prodX is int && prodX >= 0 && prodX < prodL.length)
           ? prodL[prodX] as Map<String, dynamic>?
           : null;
-      out.add(RegionalDeparture(
-        line: (prod?['name'] as String? ?? '').trim(),
-        direction: (j['dirTxt'] as String? ?? '').trim(),
-        plannedTime: _hhmmss(stop['dTimeS'] as String?),
-        plannedPlatform: _platform(stop, 'S'),
-        livePlatform: _platform(stop, 'R'),
-        notes: _himHeads(himL, [j['msgL'], stop['msgL']]),
-      ));
+      out.add(
+        RegionalDeparture(
+          line: (prod?['name'] as String? ?? '').trim(),
+          direction: (j['dirTxt'] as String? ?? '').trim(),
+          plannedTime: _hhmmss(stop['dTimeS'] as String?),
+          plannedPlatform: _platform(stop, 'S'),
+          livePlatform: _platform(stop, 'R'),
+          notes: _himHeads(himL, [j['msgL'], stop['msgL']]),
+        ),
+      );
     }
     return out;
   }
@@ -524,8 +587,10 @@ class RegionalTransitService {
     for (final profile in regionalProfilesFor(lat, lon)) {
       if (_isDead(profile)) continue;
       if (DateTime.now().isAfter(deadline)) {
-        AppLog.log('regional budget aufgebraucht, Rest übersprungen',
-            tag: 'regional');
+        AppLog.log(
+          'regional budget aufgebraucht, Rest übersprungen',
+          tag: 'regional',
+        );
         break;
       }
       final extId = profile.backend == RegionalBackend.efa
@@ -590,14 +655,18 @@ class RegionalTransitService {
     // backends: DB calls this ride "Rungholtplatz", NAH.SH calls it "Suchsdorf",
     // and a direction filter would then throw the right departure away.
     final best = near.map((e) => e.diff).reduce(math.min);
-    var pool = [for (final e in near) if (e.diff == best) e.d];
+    var pool = [
+      for (final e in near)
+        if (e.diff == best) e.d,
+    ];
 
     // Only if the exact time still leaves more than one (two lines-22 in the
     // same minute) does the destination break the tie — and a differing label
     // then just means "can't tell", never a hard "no".
     if (pool.length > 1 && wantedTo != null) {
-      final byDir =
-          pool.where((d) => _directionMatches(d.direction, wantedTo)).toList();
+      final byDir = pool
+          .where((d) => _directionMatches(d.direction, wantedTo))
+          .toList();
       if (byDir.length == 1) pool = byDir;
     }
     if (pool.length != 1) return null;
@@ -618,7 +687,10 @@ class RegionalTransitService {
   }
 
   static PlatformCorrection? _correctionOf(
-      RegionalDeparture d, String source, String? dbPlatform) {
+    RegionalDeparture d,
+    String source,
+    String? dbPlatform,
+  ) {
     if (d.moved) {
       return (
         // What DB itself says, when we know it — that is the value the rider
@@ -657,11 +729,14 @@ class RegionalTransitService {
   static String? _closureNote(RegionalDeparture d) {
     final bay = d.plannedPlatform;
     if (bay == null) return null;
-    final bayRe = RegExp(r'(^|\D)' + RegExp.escape(bay) + r'(\D|$)',
-        caseSensitive: false);
+    final bayRe = RegExp(
+      r'(^|\D)' + RegExp.escape(bay) + r'(\D|$)',
+      caseSensitive: false,
+    );
     for (final n in d.notes) {
       final low = n.toLowerCase();
-      final closed = low.contains('sperr') ||
+      final closed =
+          low.contains('sperr') ||
           low.contains('gesperrt') ||
           low.contains('entfäll') ||
           low.contains('nicht bedient') ||
@@ -697,10 +772,8 @@ class RegionalTransitService {
     return t.isEmpty ? null : t;
   }
 
-  static String _date(DateTime t) =>
-      '${t.year}${_two(t.month)}${_two(t.day)}';
-  static String _time(DateTime t) =>
-      '${_two(t.hour)}${_two(t.minute)}00';
+  static String _date(DateTime t) => '${t.year}${_two(t.month)}${_two(t.day)}';
+  static String _time(DateTime t) => '${_two(t.hour)}${_two(t.minute)}00';
   static String _two(int v) => v.toString().padLeft(2, '0');
 
   /// HAFAS "HHMMSS" → minutes since midnight. A leading day offset ("1093900",

--- a/flutter-app/lib/services/vendo_service.dart
+++ b/flutter-app/lib/services/vendo_service.dart
@@ -183,6 +183,7 @@ class VendoService {
       'fahrplan HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
       tag: 'vendo',
     );
+
     if (res.statusCode != 200) {
       // Surface the upstream body — DB encodes the real reason (bot block,
       // bad location id, rate limit) in the JSON, not just the status code.
@@ -669,16 +670,119 @@ class VendoService {
   /// `{lat, lng}` points, or null if the backend carries no geometry.
   Future<List<Map<String, double>>?> fetchTripPolyline(String zuglaufId) async {
     final url = '$_base/zuglauf/${Uri.encodeComponent(zuglaufId)}';
+
     final res = await _client
         .get(Uri.parse(url), headers: _headers(_zuglaufMedia))
         .timeout(const Duration(seconds: 10));
+
     if (res.statusCode != 200) {
       throw VendoException('Vendo zuglauf HTTP ${res.statusCode}');
     }
+
     final data =
         json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final realtime = data['echtzeitNotizen'];
+
+    AppLog.log(
+      'zuglauf echtzeitNotizen type: ${realtime.runtimeType}',
+      tag: 'vendo',
+    );
+
+    if (realtime is List) {
+      AppLog.log(
+        'zuglauf echtzeitNotizen count: ${realtime.length}',
+        tag: 'vendo',
+      );
+
+      for (final note in realtime.take(5)) {
+        AppLog.log('zuglauf echtzeitNotiz: $note', tag: 'vendo');
+      }
+    } else {
+      AppLog.log('zuglauf echtzeitNotizen value: $realtime', tag: 'vendo');
+    }
+    AppLog.log('zuglauf top-level keys: ${data.keys.toList()}', tag: 'vendo');
+    final fahrplan = data['fahrplan'];
+
+    if (fahrplan is Map<String, dynamic>) {
+      AppLog.log(
+        'zuglauf fahrplan keys: ${fahrplan.keys.toList()}',
+        tag: 'vendo',
+      );
+      final tageOhneFahrt = fahrplan['tageOhneFahrt'];
+
+      AppLog.log(
+        'zuglauf tageOhneFahrt runtimeType: '
+        '${tageOhneFahrt.runtimeType}',
+        tag: 'vendo',
+      );
+
+      AppLog.log('zuglauf tageOhneFahrt value: $tageOhneFahrt', tag: 'vendo');
+      final regulaerer = fahrplan['regulaererFahrplan'];
+
+      AppLog.log(
+        'zuglauf regulaererFahrplan runtimeType: '
+        '${regulaerer.runtimeType}',
+        tag: 'vendo',
+      );
+
+      AppLog.log('zuglauf regulaererFahrplan value: $regulaerer', tag: 'vendo');
+
+      if (regulaerer is Map<String, dynamic>) {
+        AppLog.log(
+          'zuglauf regulaererFahrplan keys: '
+          '${regulaerer.keys.toList()}',
+          tag: 'vendo',
+        );
+      } else if (regulaerer is List) {
+        AppLog.log(
+          'zuglauf regulaererFahrplan list length: '
+          '${regulaerer.length}',
+          tag: 'vendo',
+        );
+
+        if (regulaerer.isNotEmpty && regulaerer.first is Map<String, dynamic>) {
+          AppLog.log(
+            'zuglauf first regular entry keys: '
+            '${(regulaerer.first as Map<String, dynamic>).keys.toList()}',
+            tag: 'vendo',
+          );
+        }
+      }
+    }
+
+    final halte = data['halte'];
+
+    if (halte is List) {
+      AppLog.log('zuglauf halte count: ${halte.length}', tag: 'vendo');
+
+      if (halte.isNotEmpty && halte.last is Map<String, dynamic>) {
+        final lastHalt = halte.last as Map<String, dynamic>;
+
+        AppLog.log('zuglauf last halt ort: ${lastHalt['ort']}', tag: 'vendo');
+
+        AppLog.log(
+          'zuglauf last halt abgangsDatum: '
+          '${lastHalt['abgangsDatum']}',
+          tag: 'vendo',
+        );
+
+        AppLog.log(
+          'zuglauf last halt ezGleis: '
+          '${lastHalt['ezGleis']}',
+          tag: 'vendo',
+        );
+
+        AppLog.log(
+          'zuglauf last halt gleis: '
+          '${lastHalt['gleis']}',
+          tag: 'vendo',
+        );
+      }
+    }
     final points = _parsePolyline(data);
+
     AppLog.log('zuglauf polyline ${points?.length ?? 0} pts', tag: 'vendo');
+
     return points;
   }
 
@@ -854,8 +958,18 @@ class VendoService {
     // that reliably trips the backend's per-client limit and every leg fails
     // together — which is what made the detail view collapse to the minimal
     // card for *all* connections at once, then recover minutes later (#14).
+
+    final stopwatch = Stopwatch()..start();
+
     final res = await _zuglaufGate.run(
       () => _getWithRetry(url, _zuglaufMedia, tag: 'zuglauf'),
+    );
+
+    stopwatch.stop();
+
+    AppLog.log(
+      'zuglauf E2E = ${stopwatch.elapsedMilliseconds} ms',
+      tag: 'vendo',
     );
     return json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
   }
@@ -866,7 +980,8 @@ class VendoService {
 
   /// GET honouring 429 + `Retry-After`. The backend answers a tripped limit
   /// with `{"domain":"MOB","code":"RETRY","status":"ERROR"}` and a
-  /// `Retry-After` (~18s observed), i.e. it tells us exactly when to come
+  /// `Retry-After` (~18s observed), i.e. it tells us ex
+  /// actly when to come
   /// back — treating that as a hard failure throws away a request that would
   /// have succeeded. Mirrors DbAccountService's existing 429 backoff.
   Future<http.Response> _getWithRetry(
@@ -875,27 +990,44 @@ class VendoService {
     required String tag,
     int attempt = 0,
   }) async {
+    final stopwatch = Stopwatch()..start();
+
     final res = await _client
         .get(Uri.parse(url), headers: _headers(media))
         .timeout(const Duration(seconds: 10));
+
+    stopwatch.stop();
+
+    AppLog.log(
+      'zuglauf API attempt ${attempt + 1} = '
+      '${stopwatch.elapsedMilliseconds} ms',
+      tag: 'vendo',
+    );
+
     if (res.statusCode == 429 && attempt < _maxRetries) {
       final retryAfter = int.tryParse(res.headers['retry-after'] ?? '');
+
       // No Retry-After → exponential backoff (2s, 4s). Cap the honoured wait:
       // a rider staring at a spinner won't sit through a 60s hint.
       final delay = Duration(
         seconds: (retryAfter ?? (2 << attempt)).clamp(1, 20),
       );
+
       AppLog.log(
         '429 on $tag → backoff ${delay.inSeconds}s '
         '(attempt ${attempt + 1}/$_maxRetries)',
         tag: 'vendo',
       );
+
       await Future.delayed(delay);
+
       return _getWithRetry(url, media, tag: tag, attempt: attempt + 1);
     }
+
     if (res.statusCode != 200) {
       throw VendoException('Vendo $tag HTTP ${res.statusCode}');
     }
+
     return res;
   }
 
@@ -1404,6 +1536,31 @@ class VendoService {
     collect(a['echtzeitNotizen']);
     for (final h in halte.whereType<Map<String, dynamic>>()) {
       // See _parseTripFromZuglauf: stop-level notes live in `echtzeitNotizen`.
+      for (final halt in halte.whereType<Map<String, dynamic>>()) {
+        final ort = halt['ort'] as Map<String, dynamic>?;
+
+        AppLog.log('halt ${ort?['name']}', tag: 'vendo');
+
+        final auslastung = halt['auslastungsInfos'];
+
+        AppLog.log(
+          '  auslastungsInfos type: ${auslastung.runtimeType}',
+          tag: 'vendo',
+        );
+
+        if (auslastung is List) {
+          AppLog.log(
+            '  auslastungsInfos count: ${auslastung.length}',
+            tag: 'vendo',
+          );
+
+          for (final info in auslastung.take(3)) {
+            AppLog.log('  auslastung: $info', tag: 'vendo');
+          }
+        } else {
+          AppLog.log('  auslastungsInfos value: $auslastung', tag: 'vendo');
+        }
+      }
       collect(h['echtzeitNotizen']);
     }
 

--- a/flutter-app/lib/services/vendo_service.dart
+++ b/flutter-app/lib/services/vendo_service.dart
@@ -146,15 +146,11 @@ class VendoService {
             'zeitPunktArt': isArrival ? 'ANKUNFT' : 'ABFAHRT',
           },
           'zielLocationId': toLocationId,
-          if (minTransferMinutes != null)
-            'minUmstiegsdauer': minTransferMinutes,
-          if (maxTransfers != null) 'maxUmstiege': maxTransfers,
+          'minUmstiegsdauer': ?minTransferMinutes,
+          'maxUmstiege': ?maxTransfers,
           if (viaLocations != null && viaLocations.isNotEmpty)
             'viaLocations': viaLocations,
-          // Earlier/later pagination: the DB Navigator backend returns
-          // frueherContext/spaeterContext tokens; replaying one here scrolls
-          // the result window. Field is `context` (English), not `kontext`.
-          if (context != null) 'context': context,
+          'context': ?context,
         },
       },
       'reisendenProfil': {'reisende': reisendeJson},
@@ -433,7 +429,7 @@ class VendoService {
           'zeitPunktArt': 'ANKUNFT',
         },
         'zielLocationId': zielLocationId,
-        if (context != null) 'context': context,
+        'context': ?context,
       },
     };
     final url = '$_base/trip/weitereabfahrten';

--- a/flutter-app/lib/services/vendo_service.dart
+++ b/flutter-app/lib/services/vendo_service.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
+
 import 'package:http/http.dart' as http;
+
 import '../core/app_log.dart';
-import '../models/station.dart';
-import 'db_api_service.dart' show SegmentPrice;
 import '../models/best_price.dart';
-import '../models/walking_route.dart';
 import '../models/departure.dart';
 import '../models/journey.dart';
+import '../models/station.dart';
 import '../models/trip.dart';
+import '../models/walking_route.dart';
+import 'db_api_service.dart' show SegmentPrice;
 
 /// Client for the DB Navigator mobile backend (`app.services-bahn.de/mob`).
 ///
@@ -70,13 +72,13 @@ class VendoService {
   final _rng = Random();
 
   Map<String, String> _headers(String media) => {
-        'Accept': media,
-        'Content-Type': media,
-        'Accept-Language': 'de',
-        'User-Agent': 'DBNavigator/Android/26.9.0',
-        'X-App-Version': '26.9.0',
-        'X-Correlation-ID': '${_uuid()}_${_uuid()}',
-      };
+    'Accept': media,
+    'Content-Type': media,
+    'Accept-Language': 'de',
+    'User-Agent': 'DBNavigator/Android/26.9.0',
+    'X-App-Version': '26.9.0',
+    'X-Correlation-ID': '${_uuid()}_${_uuid()}',
+  };
 
   /// Search journeys with offers/prices. [fromLocationId]/[toLocationId] are the
   /// full HAFAS location strings ([Station.vendoLocationId]).
@@ -121,7 +123,7 @@ class VendoService {
             {
               'ermaessigungen': ['KEINE_ERMAESSIGUNG KLASSENLOS'],
               'reisendenTyp': 'ERWACHSENER',
-            }
+            },
           ]
         : reisende;
     final body = {
@@ -155,29 +157,36 @@ class VendoService {
           if (context != null) 'context': context,
         },
       },
-      'reisendenProfil': {
-        'reisende': reisendeJson,
-      },
+      'reisendenProfil': {'reisende': reisendeJson},
       'reservierungsKontingenteVorhanden': false,
     };
 
     final url = '$_base/angebote/fahrplan';
-    AppLog.log('journey ${fromLocationId.split('@O=').last.split('@').first}'
-        ' → ${toLocationId.split('@O=').last.split('@').first}', tag: 'vendo');
-    AppLog.log('POST $url klasse=${firstClass ? 1 : 2} '
-        'isArrival=$isArrival dt=${_isoWithOffset(dateTime ?? DateTime.now())}',
-        tag: 'vendo');
+    AppLog.log(
+      'journey ${fromLocationId.split('@O=').last.split('@').first}'
+      ' → ${toLocationId.split('@O=').last.split('@').first}',
+      tag: 'vendo',
+    );
+    AppLog.log(
+      'POST $url klasse=${firstClass ? 1 : 2} '
+      'isArrival=$isArrival dt=${_isoWithOffset(dateTime ?? DateTime.now())}',
+      tag: 'vendo',
+    );
     // NB: pass the body as BYTES, not a String. package:http appends
     // `; charset=utf-8` to the Content-Type of a String body, and the DB edge
     // exact-matches the vendo media type — the charset variant is rejected with
     // HTTP 405 (0B). Bytes leave the Content-Type header untouched.
     final res = await _client
-        .post(Uri.parse(url),
-            headers: _headers(_journeyMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse(url),
+          headers: _headers(_journeyMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 12));
-    AppLog.log('fahrplan HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
-        tag: 'vendo');
+    AppLog.log(
+      'fahrplan HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 200) {
       // Surface the upstream body — DB encodes the real reason (bot block,
       // bad location id, rate limit) in the JSON, not just the status code.
@@ -189,10 +198,12 @@ class VendoService {
       // — prefer that over the raw JSON so the party sheet gets actionable
       // feedback ("Bitte wählen Sie die 2. Klasse.").
       final friendly = _dbAnzeigeText(res.bodyBytes);
-      throw VendoException(friendly ??
-          'Vendo fahrplan HTTP ${res.statusCode}: $snippet');
+      throw VendoException(
+        friendly ?? 'Vendo fahrplan HTTP ${res.statusCode}: $snippet',
+      );
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final conns = data['verbindungen'] as List<dynamic>? ?? [];
     AppLog.log('${conns.length} journeys parsed', tag: 'vendo');
     return JourneyResult(
@@ -231,26 +242,36 @@ class VendoService {
     };
     final url = '$_base/location/calculateroute';
     final res = await _client
-        .post(Uri.parse(url),
-            headers: _headers(_locationMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse(url),
+          headers: _headers(_locationMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 10));
-    AppLog.log('calculateroute HTTP ${res.statusCode} '
-        '(${res.bodyBytes.length}B)', tag: 'vendo');
+    AppLog.log(
+      'calculateroute HTTP ${res.statusCode} '
+      '(${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 200) {
       // A route that can't be computed is not worth an exception — the map is
       // useful without it.
-      AppLog.log('calculateroute failed: ${_snippet(res.bodyBytes)}',
-          tag: 'vendo');
+      AppLog.log(
+        'calculateroute failed: ${_snippet(res.bodyBytes)}',
+        tag: 'vendo',
+      );
       return null;
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final points = (data['gpsPositions'] as List<dynamic>? ?? const [])
         .whereType<Map<String, dynamic>>()
-        .map((p) => (
-              lat: (p['latitude'] as num?)?.toDouble(),
-              lon: (p['longitude'] as num?)?.toDouble(),
-            ))
+        .map(
+          (p) => (
+            lat: (p['latitude'] as num?)?.toDouble(),
+            lon: (p['longitude'] as num?)?.toDouble(),
+          ),
+        )
         .where((p) => p.lat != null && p.lon != null)
         .map((p) => WalkingPoint(p.lat!, p.lon!))
         .toList();
@@ -317,7 +338,7 @@ class VendoService {
                 {
                   'ermaessigungen': ['KEINE_ERMAESSIGUNG KLASSENLOS'],
                   'reisendenTyp': 'ERWACHSENER',
-                }
+                },
               ]
             : reisende,
       },
@@ -325,23 +346,34 @@ class VendoService {
     };
 
     final url = '$_base/angebote/tagesbestpreis';
-    AppLog.log('POST $url day=${_isoWithOffset(day)} '
-        'klasse=${firstClass ? 1 : 2}', tag: 'vendo');
+    AppLog.log(
+      'POST $url day=${_isoWithOffset(day)} '
+      'klasse=${firstClass ? 1 : 2}',
+      tag: 'vendo',
+    );
     // Bytes, not a String — see searchJourneys: a charset on the vendo media
     // type is rejected with a 405.
     final res = await _client
-        .post(Uri.parse(url),
-            headers: _headers(_journeyMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse(url),
+          headers: _headers(_journeyMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 20));
-    AppLog.log('tagesbestpreis HTTP ${res.statusCode} '
-        '(${res.bodyBytes.length}B)', tag: 'vendo');
+    AppLog.log(
+      'tagesbestpreis HTTP ${res.statusCode} '
+      '(${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 200) {
-      throw VendoException(_dbAnzeigeText(res.bodyBytes) ??
-          'Vendo tagesbestpreis HTTP ${res.statusCode}: '
-              '${_snippet(res.bodyBytes)}');
+      throw VendoException(
+        _dbAnzeigeText(res.bodyBytes) ??
+            'Vendo tagesbestpreis HTTP ${res.statusCode}: '
+                '${_snippet(res.bodyBytes)}',
+      );
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final intervals = (data['tagesbestPreisIntervalle'] as List<dynamic>? ?? [])
         .whereType<Map<String, dynamic>>()
         .map((iv) => _parseBestPriceInterval(iv, firstClass: firstClass))
@@ -354,8 +386,10 @@ class VendoService {
 
   /// One `tagesbestPreisIntervalle` entry. Null when it has no bounds — those
   /// are the only field the UI can't do without.
-  BestPriceInterval? _parseBestPriceInterval(Map<String, dynamic> iv,
-      {bool firstClass = false}) {
+  BestPriceInterval? _parseBestPriceInterval(
+    Map<String, dynamic> iv, {
+    bool firstClass = false,
+  }) {
     final from = _parse(iv['intervallAb']);
     final to = _parse(iv['intervallBis']);
     if (from == null || to == null) return null;
@@ -403,21 +437,31 @@ class VendoService {
       },
     };
     final url = '$_base/trip/weitereabfahrten';
-    AppLog.log('weitereabfahrten gattung=$produktGattungen '
-        'an=${_isoWithOffset(ankunft)}${context != null ? ' (mehr)' : ''}',
-        tag: 'vendo');
+    AppLog.log(
+      'weitereabfahrten gattung=$produktGattungen '
+      'an=${_isoWithOffset(ankunft)}${context != null ? ' (mehr)' : ''}',
+      tag: 'vendo',
+    );
     final res = await _client
-        .post(Uri.parse(url),
-            headers: _headers(_journeyMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse(url),
+          headers: _headers(_journeyMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 12));
-    AppLog.log('weitereabfahrten HTTP ${res.statusCode} '
-        '(${res.bodyBytes.length}B)', tag: 'vendo');
+    AppLog.log(
+      'weitereabfahrten HTTP ${res.statusCode} '
+      '(${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 200) {
-      throw VendoException('Vendo weitereabfahrten HTTP ${res.statusCode}: '
-          '${_snippet(res.bodyBytes)}');
+      throw VendoException(
+        'Vendo weitereabfahrten HTTP ${res.statusCode}: '
+        '${_snippet(res.bodyBytes)}',
+      );
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final conns = data['verbindungen'] as List<dynamic>? ?? [];
     return JourneyResult(
       journeys: conns
@@ -497,17 +541,25 @@ class VendoService {
     };
     final url = '$_base/angebote/verbindung/teilen';
     final res = await _client
-        .post(Uri.parse(url),
-            headers: _headers(_shareMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse(url),
+          headers: _headers(_shareMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 10));
-    AppLog.log('teilen HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
-        tag: 'vendo');
+    AppLog.log(
+      'teilen HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 201 && res.statusCode != 200) {
-      AppLog.log('teilen non-2xx body: ${_snippet(res.bodyBytes)}', tag: 'vendo');
+      AppLog.log(
+        'teilen non-2xx body: ${_snippet(res.bodyBytes)}',
+        tag: 'vendo',
+      );
       return null;
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final vbid = data['vbid'] as String?;
     if (vbid == null || vbid.isEmpty) return null;
     final link = 'https://www.bahn.de/buchung/start?vbid=$vbid';
@@ -560,8 +612,11 @@ class VendoService {
     final lookup = await _client
         .get(Uri.parse(lookupUrl), headers: _headers(_shareMedia))
         .timeout(const Duration(seconds: 12));
-    AppLog.log('share lookup HTTP ${lookup.statusCode} '
-        '(${lookup.bodyBytes.length}B)', tag: 'vendo');
+    AppLog.log(
+      'share lookup HTTP ${lookup.statusCode} '
+      '(${lookup.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (lookup.statusCode != 200) return null;
     final share =
         json.decode(utf8.decode(lookup.bodyBytes)) as Map<String, dynamic>;
@@ -583,21 +638,26 @@ class VendoService {
                 {
                   'ermaessigungen': ['KEINE_ERMAESSIGUNG KLASSENLOS'],
                   'reisendenTyp': 'ERWACHSENER',
-                }
+                },
               ]
             : reisende,
       },
       'reservierungsKontingenteVorhanden': false,
     };
     final res = await _client
-        .post(Uri.parse('$_base/angebote/recon'),
-            headers: _headers(_journeyMedia),
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse('$_base/angebote/recon'),
+          headers: _headers(_journeyMedia),
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 15));
-    AppLog.log('recon HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
-        tag: 'vendo');
+    AppLog.log(
+      'recon HTTP ${res.statusCode} (${res.bodyBytes.length}B)',
+      tag: 'vendo',
+    );
     if (res.statusCode != 200) return null;
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     // `{verbindung, angebote}` — the same shape as one element of a search
     // result's `verbindungen`, so the normal parser reads it as-is.
     final journey = _parseConnection(data, firstClass: firstClass);
@@ -619,7 +679,8 @@ class VendoService {
     if (res.statusCode != 200) {
       throw VendoException('Vendo zuglauf HTTP ${res.statusCode}');
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final points = _parsePolyline(data);
     AppLog.log('zuglauf polyline ${points?.length ?? 0} pts', tag: 'vendo');
     return points;
@@ -655,16 +716,24 @@ class VendoService {
   // (and [getTrip]) consumes, so a board row taps straight through to detail.
   // ==========================================================================
 
-  Future<List<Departure>> getDepartures(String evaId,
-          {DateTime? when, int results = 40}) =>
-      _fetchBoard(evaId, when: when, results: results, arrivals: false);
+  Future<List<Departure>> getDepartures(
+    String evaId, {
+    DateTime? when,
+    int results = 40,
+  }) => _fetchBoard(evaId, when: when, results: results, arrivals: false);
 
-  Future<List<Departure>> getArrivals(String evaId,
-          {DateTime? when, int results = 40}) =>
-      _fetchBoard(evaId, when: when, results: results, arrivals: true);
+  Future<List<Departure>> getArrivals(
+    String evaId, {
+    DateTime? when,
+    int results = 40,
+  }) => _fetchBoard(evaId, when: when, results: results, arrivals: true);
 
-  Future<List<Departure>> _fetchBoard(String evaId,
-      {DateTime? when, int results = 40, required bool arrivals}) async {
+  Future<List<Departure>> _fetchBoard(
+    String evaId, {
+    DateTime? when,
+    int results = 40,
+    required bool arrivals,
+  }) async {
     final now = when ?? DateTime.now();
     String two(int v) => v.toString().padLeft(2, '0');
     final body = {
@@ -675,15 +744,18 @@ class VendoService {
     };
     final path = arrivals ? 'ankunft' : 'abfahrt';
     final res = await _client
-        .post(Uri.parse('$_base/bahnhofstafel/$path'),
-            headers: _headers(_bahnhofstafelMedia),
-            // Bytes, not String — a charset param on Content-Type is rejected.
-            body: utf8.encode(json.encode(body)))
+        .post(
+          Uri.parse('$_base/bahnhofstafel/$path'),
+          headers: _headers(_bahnhofstafelMedia),
+          // Bytes, not String — a charset param on Content-Type is rejected.
+          body: utf8.encode(json.encode(body)),
+        )
         .timeout(const Duration(seconds: 10));
     if (res.statusCode != 200) {
       throw VendoException('Vendo bahnhofstafel/$path HTTP ${res.statusCode}');
     }
-    final data = json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+    final data =
+        json.decode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
     final key = arrivals
         ? 'bahnhofstafelAnkunftPositionen'
         : 'bahnhofstafelAbfahrtPositionen';
@@ -695,13 +767,14 @@ class VendoService {
         .toList();
   }
 
-  Departure _departureFromBoard(Map<String, dynamic> p,
-      {required bool arrivals}) {
-    final planned =
-        _parse(arrivals ? p['ankunftsDatum'] : p['abgangsDatum']);
+  Departure _departureFromBoard(
+    Map<String, dynamic> p, {
+    required bool arrivals,
+  }) {
+    final planned = _parse(arrivals ? p['ankunftsDatum'] : p['abgangsDatum']);
     final actual =
         _parse(arrivals ? p['ezAnkunftsDatum'] : p['ezAbgangsDatum']) ??
-            planned;
+        planned;
     final delay = (planned != null && actual != null)
         ? actual.difference(planned).inSeconds
         : null;
@@ -723,7 +796,9 @@ class VendoService {
         .toList();
     return Departure(
       tripId: p['zuglaufId'] as String? ?? '',
-      stop: _stationFromVendo(p['abfrageOrt'] as Map<String, dynamic>? ?? const {}),
+      stop: _stationFromVendo(
+        p['abfrageOrt'] as Map<String, dynamic>? ?? const {},
+      ),
       when: actual ?? planned,
       plannedWhen: planned,
       delay: delay,
@@ -731,10 +806,9 @@ class VendoService {
       plannedPlatform: gleis,
       direction: direction,
       line: TransitLine(
-        name: p['mitteltext'] as String? ??
-            p['kurztext'] as String? ??
-            gattung,
-        fahrtNr: p['zugnummer']?.toString() ??
+        name: p['mitteltext'] as String? ?? p['kurztext'] as String? ?? gattung,
+        fahrtNr:
+            p['zugnummer']?.toString() ??
             p['verkehrsmittelNummer'] as String? ??
             '',
         productName: p['kurztext'] as String? ?? gattung,
@@ -816,9 +890,10 @@ class VendoService {
         seconds: (retryAfter ?? (2 << attempt)).clamp(1, 20),
       );
       AppLog.log(
-          '429 on $tag → backoff ${delay.inSeconds}s '
-          '(attempt ${attempt + 1}/$_maxRetries)',
-          tag: 'vendo');
+        '429 on $tag → backoff ${delay.inSeconds}s '
+        '(attempt ${attempt + 1}/$_maxRetries)',
+        tag: 'vendo',
+      );
       await Future.delayed(delay);
       return _getWithRetry(url, media, tag: tag, attempt: attempt + 1);
     }
@@ -837,7 +912,8 @@ class VendoService {
 
     final gattung = data['produktGattung'] as String? ?? '';
     final zugnummer = data['zugnummer']?.toString() ?? '';
-    final displayName = (data['mitteltext'] as String?)?.trim().isNotEmpty == true
+    final displayName =
+        (data['mitteltext'] as String?)?.trim().isNotEmpty == true
         ? data['mitteltext'] as String
         : '$gattung $zugnummer'.trim();
 
@@ -955,8 +1031,10 @@ class VendoService {
 
   /// DB `auslastungsInfos` (per stop) → 2nd-class [OccupancyLevel], reusing the
   /// shared `stufe` mapping. Shape: `[{klasse: KLASSE_2, stufe: 1}]`.
-  OccupancyLevel _occupancyFrom(List<dynamic>? infos,
-      {bool firstClass = false}) {
+  OccupancyLevel _occupancyFrom(
+    List<dynamic>? infos, {
+    bool firstClass = false,
+  }) {
     return _levelForClass(infos, firstClass: firstClass) ??
         OccupancyLevel.unknown;
   }
@@ -987,17 +1065,21 @@ class VendoService {
         toLocationId: _loc(to),
         dateTime: dateTime,
         firstClass: firstClass,
-        reisende: reisende ??
+        reisende:
+            reisende ??
             [
               {
                 'reisendenTyp': 'ERWACHSENER',
                 'ermaessigungen': [ermaessigung],
-              }
+              },
             ],
         deutschlandTicket: deutschlandTicket,
       );
       if (result.journeys.isEmpty) {
-        return const SegmentPrice(price: double.infinity, isDTicketCovered: false);
+        return const SegmentPrice(
+          price: double.infinity,
+          isDTicketCovered: false,
+        );
       }
 
       // NOTE: no D-Ticket coverage inference here. It used to return 0,00 € if
@@ -1033,7 +1115,10 @@ class VendoService {
           .whereType<double>()
           .toList();
       if (prices.isEmpty) {
-        return const SegmentPrice(price: double.infinity, isDTicketCovered: false);
+        return const SegmentPrice(
+          price: double.infinity,
+          isDTicketCovered: false,
+        );
       }
       // No offer matched the selected trains — fall back to the cheapest, but
       // say so, so the ticket can carry a "may be train-bound" hint instead of
@@ -1045,7 +1130,10 @@ class VendoService {
       );
     } catch (e) {
       AppLog.log('segment price failed ($e)', tag: 'vendo');
-      return const SegmentPrice(price: double.infinity, isDTicketCovered: false);
+      return const SegmentPrice(
+        price: double.infinity,
+        isDTicketCovered: false,
+      );
     }
   }
 
@@ -1094,14 +1182,20 @@ class VendoService {
   ///
   /// Duplicates are removed: the backend repeats the same address with slightly
   /// different coordinates.
-  Future<List<Station>> searchLocations(String query,
-      {bool stopsOnly = false}) async {
+  Future<List<Station>> searchLocations(
+    String query, {
+    bool stopsOnly = false,
+  }) async {
     final res = await _client.post(
       Uri.parse('$_base/location/search'),
       headers: _headers(_locationMedia),
       // Bytes, not String — see the note in searchJourneys (charset → 405).
       body: utf8.encode(
-          json.encode({'locationTypes': ['ALL'], 'searchTerm': query})),
+        json.encode({
+          'locationTypes': ['ALL'],
+          'searchTerm': query,
+        }),
+      ),
     );
     if (res.statusCode != 200) return [];
     final data = json.decode(utf8.decode(res.bodyBytes));
@@ -1137,23 +1231,31 @@ class VendoService {
     final res = await _client.post(
       Uri.parse('$_base/location/nearby/bytypes'),
       headers: _headers(_locationMedia),
-      body: utf8.encode(json.encode({
-        'area': {
-          'coordinates': {'latitude': latitude, 'longitude': longitude},
-          'radius': radius,
-        },
-        'maxResults': maxResults,
-        'operatingSystem': 'ANDROID',
-        'products': ['ALL'],
-        'types': ['ST'],
-      })),
+      body: utf8.encode(
+        json.encode({
+          'area': {
+            'coordinates': {'latitude': latitude, 'longitude': longitude},
+            'radius': radius,
+          },
+          'maxResults': maxResults,
+          'operatingSystem': 'ANDROID',
+          'products': ['ALL'],
+          'types': ['ST'],
+        }),
+      ),
     );
     if (res.statusCode != 200) return [];
     final data = json.decode(utf8.decode(res.bodyBytes));
-    final locs = (data is Map<String, dynamic>
-        ? data['fahrplanAuskunftLocations']
-        : null) as List<dynamic>? ?? const [];
-    return locs.whereType<Map<String, dynamic>>().map(_stationFromVendo).toList();
+    final locs =
+        (data is Map<String, dynamic>
+                ? data['fahrplanAuskunftLocations']
+                : null)
+            as List<dynamic>? ??
+        const [];
+    return locs
+        .whereType<Map<String, dynamic>>()
+        .map(_stationFromVendo)
+        .toList();
   }
 
   // -- parsing ---------------------------------------------------------------
@@ -1164,8 +1266,7 @@ class VendoService {
   Journey parseConnection(Map<String, dynamic> c, {bool firstClass = false}) =>
       _parseConnection(c, firstClass: firstClass);
 
-  Journey _parseConnection(Map<String, dynamic> c,
-      {bool firstClass = false}) {
+  Journey _parseConnection(Map<String, dynamic> c, {bool firstClass = false}) {
     // /angebote/fahrplan wraps the connection in `verbindung`; the
     // /trip/weitereabfahrten response puts the same fields directly on the
     // connection object — fall back to `c` so both shapes parse.
@@ -1177,14 +1278,18 @@ class VendoService {
         .toList();
 
     JourneyPrice? price;
-    final preise = (c['angebote'] as Map<String, dynamic>?)?['preise']
-        as Map<String, dynamic>?;
-    final ab = ((preise?['gesamt'] as Map<String, dynamic>?)?['ab'])
-        as Map<String, dynamic>?;
+    final preise =
+        (c['angebote'] as Map<String, dynamic>?)?['preise']
+            as Map<String, dynamic>?;
+    final ab =
+        ((preise?['gesamt'] as Map<String, dynamic>?)?['ab'])
+            as Map<String, dynamic>?;
     final betrag = (ab?['betrag'] as num?)?.toDouble();
     if (betrag != null) {
       price = JourneyPrice(
-          amount: betrag, currency: ab?['waehrung'] as String? ?? 'EUR');
+        amount: betrag,
+        currency: ab?['waehrung'] as String? ?? 'EUR',
+      );
     }
 
     return Journey(
@@ -1228,8 +1333,9 @@ class VendoService {
   static List<String> _connectionNotes(Map<String, dynamic> vb) {
     final out = <String>[];
     for (final key in const ['himNotizen', 'echtzeitNotizen']) {
-      for (final n in (vb[key] as List<dynamic>? ?? const [])
-          .whereType<Map<String, dynamic>>()) {
+      for (final n
+          in (vb[key] as List<dynamic>? ?? const [])
+              .whereType<Map<String, dynamic>>()) {
         final t = (n['text'] as String?)?.trim();
         if (t == null || t.isEmpty || t == 'textDefault') continue;
         if (!out.contains(t)) out.add(t);
@@ -1241,9 +1347,11 @@ class VendoService {
   JourneyLeg _parseLeg(Map<String, dynamic> a, {bool firstClass = false}) {
     final isWalking = a['typ'] == 'FUSSWEG';
     final origin = _stationFromVendo(
-        a['abgangsOrt'] as Map<String, dynamic>? ?? const {});
+      a['abgangsOrt'] as Map<String, dynamic>? ?? const {},
+    );
     final dest = _stationFromVendo(
-        a['ankunftsOrt'] as Map<String, dynamic>? ?? const {});
+      a['ankunftsOrt'] as Map<String, dynamic>? ?? const {},
+    );
 
     final plannedDep = _parse(a['abgangsDatum']);
     final actualDep = _parse(a['ezAbgangsDatum']) ?? plannedDep;
@@ -1272,10 +1380,13 @@ class VendoService {
     // texts mention generic "Zugausfälle" without this leg being cancelled.
     final ezAusfall = (a['echtzeitNotizen'] as List<dynamic>? ?? [])
         .whereType<Map<String, dynamic>>()
-        .any((n) =>
-            (n['text'] as String?)?.toLowerCase().contains('fällt aus') ??
-            false);
-    final cancelled = (stopovers.isNotEmpty &&
+        .any(
+          (n) =>
+              (n['text'] as String?)?.toLowerCase().contains('fällt aus') ??
+              false,
+        );
+    final cancelled =
+        (stopovers.isNotEmpty &&
             (stopovers.first.cancelled || stopovers.last.cancelled)) ||
         ezAusfall;
 
@@ -1327,8 +1438,9 @@ class VendoService {
     // it as a walk estimate there would invent a 12-minute walk across one
     // platform — hence both are only taken together.
     final available = _seconds(a['verfuegbareZeit']);
-    final walkDuration =
-        isWalking && available != null ? _seconds(a['abschnittsDauer']) : null;
+    final walkDuration = isWalking && available != null
+        ? _seconds(a['abschnittsDauer'])
+        : null;
 
     TransitLine? line;
     if (!isWalking) {
@@ -1373,18 +1485,21 @@ class VendoService {
           a['weiterfahrtAmGleichenBahnsteig'] as bool? ?? false,
       cancelled: cancelled,
       stopovers: stopovers,
-      occupancy: _occupancy(a['auslastungsInfos'] as List<dynamic>?,
-          firstClass: firstClass),
+      occupancy: _occupancy(
+        a['auslastungsInfos'] as List<dynamic>?,
+        firstClass: firstClass,
+      ),
       disruptions: disruptions,
       bike: bike,
       replacementDestination: ersatzZiel == null
           ? null
           : _stationFromVendo(
-              ersatzZiel['ort'] as Map<String, dynamic>? ?? const {}),
+              ersatzZiel['ort'] as Map<String, dynamic>? ?? const {},
+            ),
       replacementArrival: ersatzZiel == null
           ? null
           : _parse(ersatzZiel['ezAnkunftsDatum']) ??
-              _parse(ersatzZiel['ankunftsDatum']),
+                _parse(ersatzZiel['ankunftsDatum']),
       replacementArrivalPlatform:
           ersatzZiel?['ezGleis'] as String? ?? ersatzZiel?['gleis'] as String?,
     );
@@ -1414,7 +1529,8 @@ class VendoService {
   Station _stationFromVendo(Map<String, dynamic> ort) {
     // Journey halte/legs nest coords under `position`; the location-search
     // endpoint uses `coordinates` — accept either.
-    final pos = (ort['position'] ?? ort['coordinates']) as Map<String, dynamic>?;
+    final pos =
+        (ort['position'] ?? ort['coordinates']) as Map<String, dynamic>?;
     final loc = ort['locationId'] as String?;
     // Journey stops carry no locationType — those are always stops.
     final kind = LocationKind.fromVendo(ort['locationType'] as String?);
@@ -1428,9 +1544,9 @@ class VendoService {
       id: eva.isNotEmpty
           ? eva
           : (kind == LocationKind.station || lat == null || lon == null
-              ? eva
-              : '${kind.name}:${lat.toStringAsFixed(5)},'
-                  '${lon.toStringAsFixed(5)}'),
+                ? eva
+                : '${kind.name}:${lat.toStringAsFixed(5)},'
+                      '${lon.toStringAsFixed(5)}'),
       name: ort['name'] as String? ?? '',
       latitude: lat,
       longitude: lon,
@@ -1450,8 +1566,10 @@ class VendoService {
     return level == null ? null : OccupancyInfo(level: level);
   }
 
-  OccupancyLevel? _levelForClass(List<dynamic>? infos,
-      {required bool firstClass}) {
+  OccupancyLevel? _levelForClass(
+    List<dynamic>? infos, {
+    required bool firstClass,
+  }) {
     if (infos == null) return null;
     final want = firstClass ? 'KLASSE_1' : 'KLASSE_2';
     final other = firstClass ? 'KLASSE_2' : 'KLASSE_1';
@@ -1520,8 +1638,43 @@ class VendoService {
     return actual.difference(planned).inSeconds;
   }
 
-  DateTime? _parse(dynamic v) =>
-      v is String ? DateTime.tryParse(v)?.toLocal() : null;
+  DateTime? _parse(dynamic v) {
+    if (v is! String) return null;
+
+    final match = RegExp(
+      r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?',
+    ).firstMatch(v);
+
+    if (match == null) return null;
+
+    final year = int.parse(match.group(1)!);
+    final month = int.parse(match.group(2)!);
+    final day = int.parse(match.group(3)!);
+    final hour = int.parse(match.group(4)!);
+    final minute = int.parse(match.group(5)!);
+    final second = int.tryParse(match.group(6) ?? '0') ?? 0;
+
+    var millisecond = 0;
+    var microsecond = 0;
+
+    final fraction = match.group(7);
+    if (fraction != null) {
+      final padded = fraction.padRight(6, '0');
+      millisecond = int.parse(padded.substring(0, 3));
+      microsecond = int.parse(padded.substring(3, 6));
+    }
+
+    return DateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+    );
+  }
 
   /// Vendo durations (`verfuegbareZeit`, `abschnittsDauer`) are seconds.
   Duration? _seconds(dynamic v) =>

--- a/flutter-app/lib/services/vendo_service.dart
+++ b/flutter-app/lib/services/vendo_service.dart
@@ -928,7 +928,9 @@ class VendoService {
   static bool _boardCancelled(List<String> notes) {
     for (final n in notes) {
       final t = n.toLowerCase();
-      if (t.contains('entfällt') || t.contains('fällt aus')) return true;
+      if (t.contains('entfällt') || t.contains('fällt aus')) {
+        return true;
+      }
     }
     return false;
   }
@@ -1535,32 +1537,6 @@ class VendoService {
     collect(a['himNotizen']);
     collect(a['echtzeitNotizen']);
     for (final h in halte.whereType<Map<String, dynamic>>()) {
-      // See _parseTripFromZuglauf: stop-level notes live in `echtzeitNotizen`.
-      for (final halt in halte.whereType<Map<String, dynamic>>()) {
-        final ort = halt['ort'] as Map<String, dynamic>?;
-
-        AppLog.log('halt ${ort?['name']}', tag: 'vendo');
-
-        final auslastung = halt['auslastungsInfos'];
-
-        AppLog.log(
-          '  auslastungsInfos type: ${auslastung.runtimeType}',
-          tag: 'vendo',
-        );
-
-        if (auslastung is List) {
-          AppLog.log(
-            '  auslastungsInfos count: ${auslastung.length}',
-            tag: 'vendo',
-          );
-
-          for (final info in auslastung.take(3)) {
-            AppLog.log('  auslastung: $info', tag: 'vendo');
-          }
-        } else {
-          AppLog.log('  auslastungsInfos value: $auslastung', tag: 'vendo');
-        }
-      }
       collect(h['echtzeitNotizen']);
     }
 

--- a/flutter-app/lib/utils/geo_query.dart
+++ b/flutter-app/lib/utils/geo_query.dart
@@ -4,7 +4,7 @@ class GeoQuery {
   final double longitude;
 
   /// A name carried by the link (OSM/Google put the place name in the URL), so
-  /// the picked stop can be shown as "near <place>" instead of bare numbers.
+  /// the picked stop can be shown as "near `<place>`" instead of bare numbers.
   final String? label;
 
   const GeoQuery(this.latitude, this.longitude, {this.label});
@@ -43,8 +43,10 @@ final _bare = RegExp(r'^\s*(-?\d{1,3}\.\d+)\s*[,;\s]\s*(-?\d{1,3}\.\d+)\s*$');
 
 /// `geo:53.43,14.53` / `geo:53.43,14.53?z=17` (RFC 5870, what Android's share
 /// sheet and Organic Maps emit).
-final _geoUri = RegExp(r'^\s*geo:\s*(-?\d+\.?\d*)\s*,\s*(-?\d+\.?\d*)',
-    caseSensitive: false);
+final _geoUri = RegExp(
+  r'^\s*geo:\s*(-?\d+\.?\d*)\s*,\s*(-?\d+\.?\d*)',
+  caseSensitive: false,
+);
 
 /// Recognise a coordinate the user typed or pasted into a station field, or
 /// null if it's an ordinary station name.
@@ -67,8 +69,9 @@ GeoQuery? parseGeoQuery(String input) {
     // `q` while the path is a placeholder.
     final q = Uri.tryParse(text)?.queryParameters['q'];
     if (q != null) {
-      final m = RegExp(r'^(-?\d+\.?\d*),(-?\d+\.?\d*)(?:\s*\((.*)\))?$')
-          .firstMatch(q.trim());
+      final m = RegExp(
+        r'^(-?\d+\.?\d*),(-?\d+\.?\d*)(?:\s*\((.*)\))?$',
+      ).firstMatch(q.trim());
       final fromQ = _make(m?.group(1), m?.group(2), label: m?.group(3));
       if (fromQ != null) return fromQ;
     }
@@ -85,8 +88,9 @@ GeoQuery? parseGeoQuery(String input) {
   if (uri.host.contains('openstreetmap')) {
     final marker = _make(qp['mlat'], qp['mlon']);
     if (marker != null) return marker;
-    final m = RegExp(r'map=\d+\.?\d*/(-?\d+\.?\d*)/(-?\d+\.?\d*)')
-        .firstMatch(uri.fragment);
+    final m = RegExp(
+      r'map=\d+\.?\d*/(-?\d+\.?\d*)/(-?\d+\.?\d*)',
+    ).firstMatch(uri.fragment);
     if (m != null) return _make(m.group(1), m.group(2));
   }
 
@@ -99,7 +103,9 @@ GeoQuery? parseGeoQuery(String input) {
     for (final key in ['q', 'query', 'daddr']) {
       final v = qp[key];
       if (v == null) continue;
-      final m = RegExp(r'^(-?\d+\.?\d*),\s*(-?\d+\.?\d*)$').firstMatch(v.trim());
+      final m = RegExp(
+        r'^(-?\d+\.?\d*),\s*(-?\d+\.?\d*)$',
+      ).firstMatch(v.trim());
       final hit = _make(m?.group(1), m?.group(2));
       if (hit != null) return hit;
     }

--- a/flutter-app/lib/widgets/bay_departures_sheet.dart
+++ b/flutter-app/lib/widgets/bay_departures_sheet.dart
@@ -85,8 +85,9 @@ bool poiMatchesDeparture(MapPoi poi, Departure d) {
   final hay = '${poi.detail ?? ''} ${poi.name}';
   bool token(String t) =>
       t.isNotEmpty &&
-      RegExp('(^|[^0-9A-Za-z])${RegExp.escape(t)}([^0-9A-Za-z]|\$)')
-          .hasMatch(hay);
+      RegExp(
+        '(^|[^0-9A-Za-z])${RegExp.escape(t)}([^0-9A-Za-z]|\$)',
+      ).hasMatch(hay);
   return token(base) || token(raw);
 }
 
@@ -179,7 +180,9 @@ class _BayDeparturesSheetState extends ConsumerState<BayDeparturesSheet> {
         if (near.isNotEmpty && near.first.id.isNotEmpty) {
           eva = near.first.id;
         }
-      } catch (_) {/* keep searched-station eva */}
+      } catch (_) {
+        /* keep searched-station eva */
+      }
     }
 
     final all = await hafas.getDepartures(eva, results: 100);
@@ -192,8 +195,9 @@ class _BayDeparturesSheetState extends ConsumerState<BayDeparturesSheet> {
         : all.where((d) => products.contains(d.line.product)).toList();
 
     // 2) Within that mode, match the specific bay/track.
-    final matched =
-        modeDeps.where((d) => poiMatchesDeparture(widget.poi, d)).toList();
+    final matched = modeDeps
+        .where((d) => poiMatchesDeparture(widget.poi, d))
+        .toList();
     if (matched.isNotEmpty) return _BayResult(matched, true);
 
     // 3) Bay label couldn't be matched (e.g. multi-level ZOB uses a different
@@ -237,8 +241,10 @@ class _BayDeparturesSheetState extends ConsumerState<BayDeparturesSheet> {
               children: [
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-                  child: Text(title,
-                      style: Theme.of(context).textTheme.titleMedium),
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
                 ),
                 if (res != null && !res.matchedBay)
                   Padding(
@@ -254,14 +260,16 @@ class _BayDeparturesSheetState extends ConsumerState<BayDeparturesSheet> {
                       ? const Center(
                           child: Padding(
                             padding: EdgeInsets.all(24),
-                            child: Text('Aktuell keine Abfahrten.',
-                                textAlign: TextAlign.center),
+                            child: Text(
+                              'Aktuell keine Abfahrten.',
+                              textAlign: TextAlign.center,
+                            ),
                           ),
                         )
                       : ListView.separated(
                           controller: scrollController,
                           itemCount: deps.length,
-                          separatorBuilder: (_, __) => const Divider(height: 1),
+                          separatorBuilder: (_, _) => const Divider(height: 1),
                           itemBuilder: (_, i) => _DepartureRow(
                             dep: deps[i],
                             showBay: !(res?.matchedBay ?? true),
@@ -282,8 +290,11 @@ class _DepartureRow extends StatelessWidget {
   final Departure dep;
   final VoidCallback onTap;
   final bool showBay;
-  const _DepartureRow(
-      {required this.dep, required this.onTap, this.showBay = false});
+  const _DepartureRow({
+    required this.dep,
+    required this.onTap,
+    this.showBay = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -296,8 +307,7 @@ class _DepartureRow extends StatelessWidget {
     return ListTile(
       onTap: onTap,
       leading: _LineChip(dep: dep),
-      title:
-          Text(dep.direction, maxLines: 1, overflow: TextOverflow.ellipsis),
+      title: Text(dep.direction, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: sub.isNotEmpty ? Text(sub) : null,
       trailing: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -333,7 +343,10 @@ class _LineChip extends StatelessWidget {
       child: Text(
         label.length > 5 ? label.substring(0, 5) : label,
         style: const TextStyle(
-            color: Colors.white, fontWeight: FontWeight.bold, fontSize: 11),
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 11,
+        ),
         maxLines: 1,
       ),
     );

--- a/flutter-app/lib/widgets/journey_reliability_card.dart
+++ b/flutter-app/lib/widgets/journey_reliability_card.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+
+import '../core/journey_reliability.dart';
+import '../models/journey.dart';
+
+class JourneyReliabilityCard extends StatelessWidget {
+  final Journey journey;
+
+  const JourneyReliabilityCard({
+    super.key,
+    required this.journey,
+  });
+
+  String _title(JourneyReliabilityLevel level) {
+    switch (level) {
+      case JourneyReliabilityLevel.veryReliable:
+        return 'Sehr zuverlässig';
+      case JourneyReliabilityLevel.reliable:
+        return 'Zuverlässig';
+      case JourneyReliabilityLevel.moderate:
+        return 'Mäßig zuverlässig';
+      case JourneyReliabilityLevel.risky:
+        return 'Risiko vorhanden';
+      case JourneyReliabilityLevel.veryRisky:
+        return 'Sehr unsicher';
+    }
+  }
+
+  IconData _icon(JourneyReliabilityLevel level) {
+    switch (level) {
+      case JourneyReliabilityLevel.veryReliable:
+        return Icons.verified_rounded;
+      case JourneyReliabilityLevel.reliable:
+        return Icons.check_circle_outline_rounded;
+      case JourneyReliabilityLevel.moderate:
+        return Icons.info_outline_rounded;
+      case JourneyReliabilityLevel.risky:
+        return Icons.warning_amber_rounded;
+      case JourneyReliabilityLevel.veryRisky:
+        return Icons.error_outline_rounded;
+    }
+  }
+
+  Color _color(BuildContext context, JourneyReliabilityLevel level) {
+    final scheme = Theme.of(context).colorScheme;
+
+    switch (level) {
+      case JourneyReliabilityLevel.veryReliable:
+        return Colors.green;
+      case JourneyReliabilityLevel.reliable:
+        return scheme.primary;
+      case JourneyReliabilityLevel.moderate:
+        return Colors.orange;
+      case JourneyReliabilityLevel.risky:
+      case JourneyReliabilityLevel.veryRisky:
+        return scheme.error;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reliability = JourneyReliabilityAnalyzer.analyze(journey);
+    final color = _color(context, reliability.level);
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  _icon(reliability.level),
+                  color: color,
+                  size: 22,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Zuverlässigkeit',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                Text(
+                  '${reliability.score}/100',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _title(reliability.level),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 10),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: reliability.score / 100,
+                minHeight: 7,
+                backgroundColor:
+                    theme.colorScheme.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(color),
+              ),
+            ),
+            if (reliability.reasons.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              for (final reason in reliability.reasons)
+                Padding(
+                  padding: const EdgeInsets.only(top: 3),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.circle,
+                        size: 6,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          reason,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter-app/lib/widgets/journey_reliability_card.dart
+++ b/flutter-app/lib/widgets/journey_reliability_card.dart
@@ -6,10 +6,7 @@ import '../models/journey.dart';
 class JourneyReliabilityCard extends StatelessWidget {
   final Journey journey;
 
-  const JourneyReliabilityCard({
-    super.key,
-    required this.journey,
-  });
+  const JourneyReliabilityCard({super.key, required this.journey});
 
   String _title(JourneyReliabilityLevel level) {
     switch (level) {
@@ -72,11 +69,7 @@ class JourneyReliabilityCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                Icon(
-                  _icon(reliability.level),
-                  color: color,
-                  size: 22,
-                ),
+                Icon(_icon(reliability.level), color: color, size: 22),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
@@ -109,8 +102,7 @@ class JourneyReliabilityCard extends StatelessWidget {
               child: LinearProgressIndicator(
                 value: reliability.score / 100,
                 minHeight: 7,
-                backgroundColor:
-                    theme.colorScheme.surfaceContainerHighest,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
                 valueColor: AlwaysStoppedAnimation<Color>(color),
               ),
             ),

--- a/flutter-app/lib/widgets/station_search_field.dart
+++ b/flutter-app/lib/widgets/station_search_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/library_models.dart';
 import '../models/station.dart';
 import '../providers/library_provider.dart';
@@ -50,8 +51,7 @@ class StationSearchField extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<StationSearchField> createState() =>
-      _StationSearchFieldState();
+  ConsumerState<StationSearchField> createState() => _StationSearchFieldState();
 }
 
 class _StationSearchFieldState extends ConsumerState<StationSearchField> {
@@ -155,7 +155,8 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
               side: BorderSide(
-                  color: Theme.of(context).colorScheme.outlineVariant),
+                color: Theme.of(context).colorScheme.outlineVariant,
+              ),
             ),
             child: Consumer(
               builder: (context, ref, _) {
@@ -184,7 +185,7 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
                         context,
                         geo == null
                             ? 'Keine Treffer für „$query". Haltestelle, '
-                                'Adresse oder Ort eingeben.'
+                                  'Adresse oder Ort eingeben.'
                             : 'Keine Haltestellen in der Nähe dieser Koordinate.',
                         icon: geo == null
                             ? Icons.search_off
@@ -198,10 +199,11 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
                         children: [
                           if (geo != null)
                             _notice(
-                                context,
-                                geo.label != null
-                                    ? 'Haltestellen nahe „${geo.label}"'
-                                    : 'Haltestellen in der Nähe der Koordinate'),
+                              context,
+                              geo.label != null
+                                  ? 'Haltestellen nahe „${geo.label}"'
+                                  : 'Haltestellen in der Nähe der Koordinate',
+                            ),
                           Flexible(
                             child: ListView.builder(
                               padding: EdgeInsets.zero,
@@ -216,7 +218,7 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
                     );
                   },
                   loading: _busy,
-                  error: (_, __) => _notice(
+                  error: (_, _) => _notice(
                     context,
                     'Suche gerade nicht erreichbar — bitte erneut versuchen.',
                     icon: Icons.cloud_off,
@@ -240,7 +242,9 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
         widget.stopsOnly ? list.where((s) => s.isStop).toList() : list;
     final favorites = usable(library.favorites);
     final recents = usable(library.recents);
-    final routes = widget.onRouteSelected != null ? widget.savedRoutes : const [];
+    final routes = widget.onRouteSelected != null
+        ? widget.savedRoutes
+        : const [];
     if (routes.isEmpty && favorites.isEmpty && recents.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -277,18 +281,22 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
       title: Row(
         children: [
           Flexible(
-            child: Text(route.from.name,
-                style: const TextStyle(fontSize: 14),
-                overflow: TextOverflow.ellipsis),
+            child: Text(
+              route.from.name,
+              style: const TextStyle(fontSize: 14),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 6),
             child: Icon(Icons.arrow_forward, size: 14),
           ),
           Flexible(
-            child: Text(route.to.name,
-                style: const TextStyle(fontSize: 14),
-                overflow: TextOverflow.ellipsis),
+            child: Text(
+              route.to.name,
+              style: const TextStyle(fontSize: 14),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),
@@ -306,31 +314,36 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
   }
 
   Widget _sectionHeader(String label) => Padding(
-        padding: const EdgeInsets.fromLTRB(16, 10, 16, 4),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-            letterSpacing: 0.4,
-            color: Theme.of(context).colorScheme.primary,
-          ),
-        ),
-      );
+    padding: const EdgeInsets.fromLTRB(16, 10, 16, 4),
+    child: Text(
+      label,
+      style: TextStyle(
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.4,
+        color: Theme.of(context).colorScheme.primary,
+      ),
+    ),
+  );
 
   static Widget _busy() => const Padding(
-        padding: EdgeInsets.all(16),
-        child: Center(
-            child: SizedBox(
-                height: 24,
-                width: 24,
-                child: CircularProgressIndicator(strokeWidth: 2))),
-      );
+    padding: EdgeInsets.all(16),
+    child: Center(
+      child: SizedBox(
+        height: 24,
+        width: 24,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      ),
+    ),
+  );
 
   /// A one-line explanation inside the menu — why this list is nearby stops
   /// rather than name matches, or why there is no list at all.
-  Widget _notice(BuildContext context, String text,
-      {IconData icon = Icons.my_location}) {
+  Widget _notice(
+    BuildContext context,
+    String text, {
+    IconData icon = Icons.my_location,
+  }) {
     final scheme = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
@@ -339,8 +352,10 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
           Icon(icon, size: 15, color: scheme.primary),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(text,
-                style: TextStyle(fontSize: 12, color: scheme.onSurfaceVariant)),
+            child: Text(
+              text,
+              style: TextStyle(fontSize: 12, color: scheme.onSurfaceVariant),
+            ),
           ),
         ],
       ),
@@ -348,10 +363,10 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
   }
 
   static IconData _kindIcon(LocationKind kind) => switch (kind) {
-        LocationKind.station => Icons.train,
-        LocationKind.address => Icons.home_outlined,
-        LocationKind.poi => Icons.place_outlined,
-      };
+    LocationKind.station => Icons.train,
+    LocationKind.address => Icons.home_outlined,
+    LocationKind.poi => Icons.place_outlined,
+  };
 
   Widget _stationTile(WidgetRef ref, Station station) {
     final isFav = ref.watch(libraryProvider).isStationFavorite(station.id);
@@ -364,10 +379,13 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
       // to tell "Kieler Straße 30" (Adresse) from a stop of the same name.
       subtitle: station.isStop
           ? null
-          : Text(station.kind.label,
+          : Text(
+              station.kind.label,
               style: TextStyle(
-                  fontSize: 11,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
       trailing: IconButton(
         icon: Icon(
           isFav ? Icons.star : Icons.star_border,
@@ -424,12 +442,13 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
     // Exact name match — but ONLY if it's unambiguous, i.e. no other result
     // extends it (so "Berlin" doesn't auto-pick while "Berlin Hauptbahnhof",
     // "Berlin Ostbahnhof" … are still candidates; "Kiel Hauptbahnhof" does).
-    final exact =
-        stations.where((s) => s.name.toLowerCase() == typed).toList();
+    final exact = stations.where((s) => s.name.toLowerCase() == typed).toList();
     if (exact.length == 1) {
-      final extendedByOther = stations.any((s) =>
-          s.name.length > typed.length &&
-          s.name.toLowerCase().startsWith(typed));
+      final extendedByOther = stations.any(
+        (s) =>
+            s.name.length > typed.length &&
+            s.name.toLowerCase().startsWith(typed),
+      );
       if (!extendedByOther) _selectStation(exact.first);
     }
   }
@@ -469,8 +488,7 @@ class _StationSearchFieldState extends ConsumerState<StationSearchField> {
               ? IconButton(
                   tooltip: 'Eingabe löschen',
                   icon: Icon(Icons.clear, size: widget.dense ? 18 : 20),
-                  visualDensity:
-                      widget.dense ? VisualDensity.compact : null,
+                  visualDensity: widget.dense ? VisualDensity.compact : null,
                   onPressed: () {
                     _controller.clear();
                     ref.read(stationSearchProvider.notifier).clear();

--- a/flutter-app/performance/zuglauf_baseline.dart
+++ b/flutter-app/performance/zuglauf_baseline.dart
@@ -1,0 +1,47 @@
+// ignore_for_file: avoid_print
+void main() {
+  const requestLatencies = <int>[
+    // Real zuglauf API attempt times go here.
+  ];
+
+  const e2eLatencies = <int>[
+    // Real zuglauf E2E times go here.
+  ];
+
+  if (requestLatencies.isEmpty || e2eLatencies.isEmpty) {
+    print('No performance samples yet.');
+    return;
+  }
+
+  final requests = [...requestLatencies]..sort();
+  final e2e = [...e2eLatencies]..sort();
+
+  int percentile(List<int> values, double p) {
+    final index = ((values.length - 1) * p).round();
+    return values[index];
+  }
+
+  double average(List<int> values) {
+    return values.reduce((a, b) => a + b) / values.length;
+  }
+
+  print('');
+  print('Zuglauf API Baseline');
+  print('====================');
+  print('');
+  print('Samples: ${requests.length}');
+  print('Average: ${average(requests).toStringAsFixed(1)} ms');
+  print('Median:  ${percentile(requests, 0.50)} ms');
+  print('P95:     ${percentile(requests, 0.95)} ms');
+  print('Min:     ${requests.first} ms');
+  print('Max:     ${requests.last} ms');
+
+  print('');
+  print('Zuglauf E2E');
+  print('-----------');
+  print('Average: ${average(e2e).toStringAsFixed(1)} ms');
+  print('Median:  ${percentile(e2e, 0.50)} ms');
+  print('P95:     ${percentile(e2e, 0.95)} ms');
+  print('Min:     ${e2e.first} ms');
+  print('Max:     ${e2e.last} ms');
+}

--- a/flutter-app/test/_poi_test.dart
+++ b/flutter-app/test/_poi_test.dart
@@ -1,18 +1,17 @@
-import 'dart:io';
-import 'dart:math' as math;
-import 'package:besser_bahn/core/platform_train.dart';
-import 'package:besser_bahn/services/station_map_service.dart';
+// import 'dart:io';
+
+// import 'dart:math' as math;
+
+// import 'package:besser_bahn/core/platform_train.dart';
+// import 'package:besser_bahn/services/station_map_service.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 void main() {
   test('platform POIs', () {
-    final map = parseStationMapBody('hamburg-hbf',
-        File('test/fixtures/hamburg-hbf.rsc.txt').readAsStringSync());
-    final p7 = map.platforms.firstWhere((p) => normalizeGleis(p.name) == '7');
-    final mlon = 111320.0 * math.cos(p7.latitude * math.pi / 180);
-    double mx(double lon) => (lon - p7.longitude) * mlon;
-    double my(double lat) => (lat - p7.latitude) * 111320.0;
-    for (final p in map.platforms) {
-      print('Gleis ${p.name}: x=${mx(p.longitude).toStringAsFixed(0)} y=${my(p.latitude).toStringAsFixed(0)} level=${p.level}');
-    }
+    // final map = parseStationMapBody(
+    //   'hamburg-hbf',
+    //   File('test/fixtures/hamburg-hbf.rsc.txt').readAsStringSync(),
+    // );
+    // final p7 = map.platforms.firstWhere((p) => normalizeGleis(p.name) == '7');
   });
 }

--- a/flutter-app/test/address_search_test.dart
+++ b/flutter-app/test/address_search_test.dart
@@ -18,46 +18,55 @@ import 'package:http/testing.dart';
 /// Rows below are trimmed copies of live responses — see
 /// `api-tests/healthcheck.py::check_vendo_address_search`, which asserts the same
 /// shapes against the real endpoint.
-Map<String, dynamic> _adr(String name, double lat, double lon,
-        {String? evaNr = '981033693'}) =>
-    {
-      'locationType': 'ADR',
-      'name': name,
-      // An address really does come back with an evaNr — but a pseudo one
-      // (98x/99x), with no board and no station map behind it. Only
-      // locationType says what this is.
-      if (evaNr != null) 'evaNr': evaNr,
-      'locationId': 'A=2@O=$name@X=${(lon * 1e6).round()}@'
-          'Y=${(lat * 1e6).round()}@U=91@L=981033693@p=1779965474@',
-      'coordinates': {'latitude': lat, 'longitude': lon},
-    };
+Map<String, dynamic> _adr(
+  String name,
+  double lat,
+  double lon, {
+  String? evaNr = '981033693',
+}) => {
+  'locationType': 'ADR',
+  'name': name,
+  // An address really does come back with an evaNr — but a pseudo one
+  // (98x/99x), with no board and no station map behind it. Only
+  // locationType says what this is.
+  'evaNr': ?evaNr,
+  'locationId':
+      'A=2@O=$name@X=${(lon * 1e6).round()}@'
+      'Y=${(lat * 1e6).round()}@U=91@L=981033693@p=1779965474@',
+  'coordinates': {'latitude': lat, 'longitude': lon},
+};
 
 Map<String, dynamic> _poi(String name, double lat, double lon) => {
-      'locationType': 'POI',
-      'name': name,
-      'evaNr': '991007559',
-      'locationId': 'A=4@O=$name@U=92@L=991007559@p=1785820257@',
-      'coordinates': {'latitude': lat, 'longitude': lon},
-    };
+  'locationType': 'POI',
+  'name': name,
+  'evaNr': '991007559',
+  'locationId': 'A=4@O=$name@U=92@L=991007559@p=1785820257@',
+  'coordinates': {'latitude': lat, 'longitude': lon},
+};
 
 Map<String, dynamic> _st(String name, String eva, double lat, double lon) => {
-      'locationType': 'ST',
-      'name': name,
-      'evaNr': eva,
-      'locationId': 'A=1@O=$name@U=80@L=$eva@p=1785786650@',
-      'coordinates': {'latitude': lat, 'longitude': lon},
-    };
+  'locationType': 'ST',
+  'name': name,
+  'evaNr': eva,
+  'locationId': 'A=1@O=$name@U=80@L=$eva@p=1785786650@',
+  'coordinates': {'latitude': lat, 'longitude': lon},
+};
 
-VendoService _service(List<Map<String, dynamic>> rows,
-        {void Function(Map<String, dynamic> body)? onBody}) =>
-    VendoService(
-      client: MockClient((req) async {
-        onBody?.call(
-            json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>);
-        return http.Response.bytes(utf8.encode(json.encode(rows)), 200,
-            headers: {'content-type': 'application/json; charset=utf-8'});
-      }),
+VendoService _service(
+  List<Map<String, dynamic>> rows, {
+  void Function(Map<String, dynamic> body)? onBody,
+}) => VendoService(
+  client: MockClient((req) async {
+    onBody?.call(
+      json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>,
     );
+    return http.Response.bytes(
+      utf8.encode(json.encode(rows)),
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }),
+);
 
 void main() {
   test('address and POI hits survive the search', () async {
@@ -72,59 +81,70 @@ void main() {
       'Kiel, Agentur für Arbeit Kiel',
       'Preetz',
     ]);
-    expect(results.map((s) => s.kind),
-        [LocationKind.address, LocationKind.poi, LocationKind.station]);
+    expect(results.map((s) => s.kind), [
+      LocationKind.address,
+      LocationKind.poi,
+      LocationKind.station,
+    ]);
     expect(results.first.isStop, isFalse);
     expect(results.last.isStop, isTrue);
   });
 
-  test('an address keeps its full locationId — the journey API needs it',
-      () async {
-    final adr = (await _service([
-      _adr('24211 Preetz, Kieler Straße 30', 54.24456, 10.277403),
-    ]).searchLocations('Kieler Straße 30'))
-        .single;
+  test(
+    'an address keeps its full locationId — the journey API needs it',
+    () async {
+      final adr = (await _service([
+        _adr('24211 Preetz, Kieler Straße 30', 54.24456, 10.277403),
+      ]).searchLocations('Kieler Straße 30')).single;
 
-    expect(adr.locationId, startsWith('A=2@O=24211 Preetz, Kieler Straße 30@'));
-    expect(adr.vendoLocationId, adr.locationId);
-    expect(adr.latitude, closeTo(54.24456, 1e-6));
-  });
+      expect(
+        adr.locationId,
+        startsWith('A=2@O=24211 Preetz, Kieler Straße 30@'),
+      );
+      expect(adr.vendoLocationId, adr.locationId);
+      expect(adr.latitude, closeTo(54.24456, 1e-6));
+    },
+  );
 
-  test('an address gets a stable id — favorites/recents are keyed by it',
-      () async {
-    final adr = (await _service([
-      _adr('24211 Preetz, Kieler Straße 30', 54.24456, 10.277403),
-    ]).searchLocations('Kieler Straße 30'))
-        .single;
+  test(
+    'an address gets a stable id — favorites/recents are keyed by it',
+    () async {
+      final adr = (await _service([
+        _adr('24211 Preetz, Kieler Straße 30', 54.24456, 10.277403),
+      ]).searchLocations('Kieler Straße 30')).single;
 
-    // DB's pseudo-EVA is stable per address, so it is the key — but it is not
-    // a station: `isStop` stays false, which is what guards the boards.
-    expect(adr.id, '981033693');
-    expect(adr.isStop, isFalse);
+      // DB's pseudo-EVA is stable per address, so it is the key — but it is not
+      // a station: `isStop` stays false, which is what guards the boards.
+      expect(adr.id, '981033693');
+      expect(adr.isStop, isFalse);
 
-    final other = (await _service([
-      _adr('24211 Preetz, Danziger Straße 30', 54.244138, 10.288199,
-          evaNr: '981033643'),
-    ]).searchLocations('Danziger Straße 30'))
-        .single;
-    expect(other.id, isNot(adr.id));
-  });
+      final other = (await _service([
+        _adr(
+          '24211 Preetz, Danziger Straße 30',
+          54.244138,
+          10.288199,
+          evaNr: '981033643',
+        ),
+      ]).searchLocations('Danziger Straße 30')).single;
+      expect(other.id, isNot(adr.id));
+    },
+  );
 
   test('an address without a pseudo-EVA still gets a usable id', () async {
     // Belt and braces: an empty id made every address collide in the library
     // and silently refuse to be starred.
     final adr = (await _service([
       _adr('24211 Preetz, Kieler Straße 30', 54.24456, 10.277403, evaNr: null),
-    ]).searchLocations('Kieler Straße 30'))
-        .single;
+    ]).searchLocations('Kieler Straße 30')).single;
     expect(adr.id, 'address:54.24456,10.27740');
   });
 
   test('no synthetic EVA locationId is invented for an address', () {
     const adr = Station(
-        id: 'address:54.24456,10.27740',
-        name: '24211 Preetz, Kieler Straße 30',
-        kind: LocationKind.address);
+      id: 'address:54.24456,10.27740',
+      name: '24211 Preetz, Kieler Straße 30',
+      kind: LocationKind.address,
+    );
     // 'A=1@L=address:…@' would be nonsense to the backend — better empty.
     expect(adr.vendoLocationId, '');
   });

--- a/flutter-app/test/journey_reliability_test.dart
+++ b/flutter-app/test/journey_reliability_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:besser_bahn/core/journey_reliability.dart';
+import 'package:besser_bahn/models/journey.dart';
+
+Journey _journey({
+  int transfers = 0,
+  bool cancelled = false,
+  bool partiallyCancelled = false,
+  bool disrupted = false,
+  int? transferBufferMinutes,
+  int departureDelayMinutes = 0,
+  bool platformChange = false,
+}) {
+  final legs = <Map<String, dynamic>>[
+    {
+      'origin': {'name': 'A', 'id': 'A'},
+      'destination': {'name': 'B', 'id': 'B'},
+      'departure': '2026-08-19T10:00:00Z',
+      'arrival': '2026-08-19T10:30:00Z',
+      'cancelled': cancelled,
+      'departureDelay': departureDelayMinutes * 60,
+      'departurePlatform': platformChange ? '2' : '1',
+      'plannedDeparturePlatform': '1',
+      'stopovers': partiallyCancelled
+          ? [
+              {
+                'stop': {'name': 'X', 'id': 'X'},
+                'cancelled': true,
+              }
+            ]
+          : [],
+      'disruptions': disrupted ? ['Streckenstörung'] : [],
+    },
+  ];
+
+  for (var i = 0; i < transfers; i++) {
+    legs.add({
+      'origin': {'name': 'B', 'id': 'B'},
+      'destination': {'name': 'C', 'id': 'C'},
+      'departure': '2026-08-19T10:40:00Z',
+      'arrival': '2026-08-19T11:10:00Z',
+      'walking': true,
+      if (transferBufferMinutes != null) ...{
+        'walkingSeconds': 300,
+        'transferAvailableSeconds': transferBufferMinutes * 60,
+      },
+    });
+    legs.add({
+      'origin': {'name': 'C', 'id': 'C'},
+      'destination': {'name': 'D', 'id': 'D'},
+      'departure': '2026-08-19T11:20:00Z',
+      'arrival': '2026-08-19T12:00:00Z',
+    });
+  }
+
+  return Journey.fromJson({'legs': legs});
+}
+
+void main() {
+  group('JourneyReliabilityAnalyzer', () {
+    test('gives a perfect score to a clean direct journey', () {
+      final result = JourneyReliabilityAnalyzer.analyze(_journey());
+
+      expect(result.score, 100);
+      expect(result.level, JourneyReliabilityLevel.veryReliable);
+      expect(result.reasons, isEmpty);
+    });
+
+    test('penalizes a cancelled leg heavily', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(cancelled: true),
+      );
+
+      expect(result.score, 40);
+      expect(result.level, JourneyReliabilityLevel.risky);
+      expect(result.reasons, contains('Cancelled train'));
+    });
+
+    test('penalizes a partial cancellation', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(partiallyCancelled: true),
+      );
+
+      expect(result.score, 70);
+      expect(result.level, JourneyReliabilityLevel.moderate);
+      expect(result.reasons, contains('Partial cancellation'));
+    });
+
+    test('penalizes a significant delay', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(departureDelayMinutes: 12),
+      );
+
+      expect(result.score, 85);
+      expect(result.level, JourneyReliabilityLevel.reliable);
+      expect(result.reasons, contains('Significant delay'));
+    });
+
+    test('penalizes a short transfer buffer', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(
+          transfers: 1,
+          transferBufferMinutes: 4,
+        ),
+      );
+
+      expect(result.score, 75);
+      expect(result.level, JourneyReliabilityLevel.reliable);
+      expect(result.reasons, contains('Short transfer buffer'));
+    });
+
+    test('penalizes platform changes', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(platformChange: true),
+      );
+
+      expect(result.score, 92);
+      expect(result.level, JourneyReliabilityLevel.veryReliable);
+      expect(result.reasons, contains('Platform change'));
+    });
+
+    test('clamps the final score to zero', () {
+      final result = JourneyReliabilityAnalyzer.analyze(
+        _journey(
+          transfers: 3,
+          cancelled: true,
+          disrupted: true,
+          departureDelayMinutes: 20,
+          transferBufferMinutes: 2,
+          platformChange: true,
+        ),
+      );
+
+      expect(result.score, greaterThanOrEqualTo(0));
+      expect(result.score, lessThanOrEqualTo(100));
+    });
+  });
+}

--- a/flutter-app/test/split_traveller_payload_test.dart
+++ b/flutter-app/test/split_traveller_payload_test.dart
@@ -62,8 +62,10 @@ void main() {
 
     test('without a BahnCard, weitere is still not mistaken for one', () {
       final erm = _reductions(
-          DbApiService.createTravellerPayload(weitere: Reduction.atVorteil)
-              .single);
+        DbApiService.createTravellerPayload(
+          weitere: Reduction.atVorteil,
+        ).single,
+      );
       expect(erm.length, 2);
       expect(erm.first['art'], 'KEINE_ERMAESSIGUNG');
       expect(erm.last['art'], 'A-VORTEILSCARD');
@@ -91,32 +93,43 @@ void main() {
       return c;
     }
 
-    test('a customised party keeps its Halbtax, SBA and extra travellers', () async {
-      final c = await container();
-      final notifier = c.read(settingsProvider.notifier);
-      const halbtax = Reduction.chHalbtax;
-      const sba = SbaOption.beeintrMitRolli;
+    test(
+      'a customised party keeps its Halbtax, SBA and extra travellers',
+      () async {
+        final c = await container();
+        final notifier = c.read(settingsProvider.notifier);
+        const halbtax = Reduction.chHalbtax;
+        const sba = SbaOption.beeintrMitRolli;
 
-      notifier.setSearchParty(const SearchParty(
-        travelers: [
-          Traveler(
-            typ: TravelerType.erwachsener,
-            weitere: halbtax,
-            sba: sba,
+        notifier.setSearchParty(
+          const SearchParty(
+            travelers: [
+              Traveler(
+                typ: TravelerType.erwachsener,
+                weitere: halbtax,
+                sba: sba,
+              ),
+              Traveler(typ: TravelerType.familienkind, alter: 8),
+            ],
           ),
-          const Traveler(typ: TravelerType.familienkind, alter: 8),
-        ],
-      ));
-      notifier.setBahnCard(BahnCardType.bc25_2);
-      await settle();
+        );
+        notifier.setBahnCard(BahnCardType.bc25_2);
+        await settle();
 
-      final party = c.read(settingsProvider).searchParty;
-      expect(party.travelers.length, 2, reason: 'party must not be re-seeded');
-      expect(party.travelers.first.bahnCard.vendoKey,
-          BahnCardType.bc25_2.vendoErmaessigung);
-      expect(party.travelers.first.weitere, halbtax);
-      expect(party.travelers.first.sba, sba);
-    });
+        final party = c.read(settingsProvider).searchParty;
+        expect(
+          party.travelers.length,
+          2,
+          reason: 'party must not be re-seeded',
+        );
+        expect(
+          party.travelers.first.bahnCard.vendoKey,
+          BahnCardType.bc25_2.vendoErmaessigung,
+        );
+        expect(party.travelers.first.weitere, halbtax);
+        expect(party.travelers.first.sba, sba);
+      },
+    );
 
     test('a 1st-class card implies 1st class', () async {
       final c = await container();
@@ -137,19 +150,24 @@ void main() {
       expect(c.read(settingsProvider).searchParty.firstClass, isTrue);
     });
 
-    test('setWeitereReduction reaches the travellers without touching the card',
-        () async {
-      final c = await container();
-      final notifier = c.read(settingsProvider.notifier);
-      const halbtax = Reduction.chHalbtax;
+    test(
+      'setWeitereReduction reaches the travellers without touching the card',
+      () async {
+        final c = await container();
+        final notifier = c.read(settingsProvider.notifier);
+        const halbtax = Reduction.chHalbtax;
 
-      notifier.setBahnCard(BahnCardType.bc50_2);
-      notifier.setWeitereReduction(halbtax);
-      await settle();
+        notifier.setBahnCard(BahnCardType.bc50_2);
+        notifier.setWeitereReduction(halbtax);
+        await settle();
 
-      final traveler = c.read(settingsProvider).searchParty.travelers.first;
-      expect(traveler.weitere, halbtax);
-      expect(traveler.bahnCard.vendoKey, BahnCardType.bc50_2.vendoErmaessigung);
-    });
+        final traveler = c.read(settingsProvider).searchParty.travelers.first;
+        expect(traveler.weitere, halbtax);
+        expect(
+          traveler.bahnCard.vendoKey,
+          BahnCardType.bc50_2.vendoErmaessigung,
+        );
+      },
+    );
   });
 }

--- a/flutter-app/test/station_search_stale_test.dart
+++ b/flutter-app/test/station_search_stale_test.dart
@@ -2,8 +2,8 @@ import 'package:besser_bahn/models/station.dart';
 import 'package:besser_bahn/providers/service_providers.dart';
 import 'package:besser_bahn/providers/station_search_provider.dart';
 import 'package:besser_bahn/services/hafas_service.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /// The suggestion list must answer the text that is in the field *now*.
 ///
@@ -20,8 +20,10 @@ class _ScriptedHafas extends HafasService {
   _ScriptedHafas(this.script);
 
   @override
-  Future<List<Station>> searchStations(String query,
-      {bool stopsOnly = false}) async {
+  Future<List<Station>> searchStations(
+    String query, {
+    bool stopsOnly = false,
+  }) async {
     queries.add(query);
     final entry = script[query] ?? (Duration.zero, const <String>[]);
     await Future<void>.delayed(entry.$1);
@@ -33,8 +35,10 @@ class _ScriptedHafas extends HafasService {
 }
 
 /// Waits until [test] holds, so the assertions don't depend on exact timing.
-Future<void> _until(bool Function() test,
-    {Duration limit = const Duration(seconds: 3)}) async {
+Future<void> _until(
+  bool Function() test, {
+  Duration limit = const Duration(seconds: 3),
+}) async {
   final deadline = DateTime.now().add(limit);
   while (!test()) {
     if (DateTime.now().isAfter(deadline)) fail('condition never held');
@@ -45,10 +49,11 @@ Future<void> _until(bool Function() test,
 void main() {
   ProviderContainer containerWith(_ScriptedHafas hafas) {
     final c = ProviderContainer(
-        overrides: [hafasServiceProvider.overrideWithValue(hafas)]);
+      overrides: [hafasServiceProvider.overrideWithValue(hafas)],
+    );
     addTearDown(c.dispose);
     // Keep the auto-dispose provider alive for the length of the test.
-    addTearDown(c.listen(stationSearchProvider, (_, __) {}).close);
+    addTearDown(c.listen(stationSearchProvider, (_, _) {}).close);
     return c;
   }
 
@@ -66,8 +71,9 @@ void main() {
     expect(hafas.queries, ['Kiel']);
 
     notifier.search('Preetz');
-    await _until(() =>
-        c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false);
+    await _until(
+      () => c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false,
+    );
     expect(c.read(stationSearchProvider).value!.query, 'Preetz');
 
     // Now the slow "Kiel" answer lands — and must be dropped.
@@ -77,28 +83,31 @@ void main() {
     expect(result.stations.single.name, 'Preetz');
   });
 
-  test('results for the old query are dropped the moment a new one is typed',
-      () async {
-    final hafas = _ScriptedHafas({
-      'Kiel': (Duration.zero, ['Kiel Hbf']),
-      'Preetz': (const Duration(milliseconds: 500), ['Preetz']),
-    });
-    final c = containerWith(hafas);
-    final notifier = c.read(stationSearchProvider.notifier);
+  test(
+    'results for the old query are dropped the moment a new one is typed',
+    () async {
+      final hafas = _ScriptedHafas({
+        'Kiel': (Duration.zero, ['Kiel Hbf']),
+        'Preetz': (const Duration(milliseconds: 500), ['Preetz']),
+      });
+      final c = containerWith(hafas);
+      final notifier = c.read(stationSearchProvider.notifier);
 
-    notifier.search('Kiel');
-    await _until(() =>
-        c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false);
+      notifier.search('Kiel');
+      await _until(
+        () => c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false,
+      );
 
-    notifier.search('Preetz');
-    // The field shows a spinner, not Kiel Hbf. Riverpod keeps the old value
-    // attached to the loading state, so being loading is only half of it: the
-    // leftover data must also be recognisable as an answer to the *old* query.
-    final pending = c.read(stationSearchProvider);
-    expect(pending.isLoading, isTrue);
-    expect(pending.value!.matches('Preetz'), isFalse);
-    expect(pending.value!.query, 'Kiel');
-  });
+      notifier.search('Preetz');
+      // The field shows a spinner, not Kiel Hbf. Riverpod keeps the old value
+      // attached to the loading state, so being loading is only half of it: the
+      // leftover data must also be recognisable as an answer to the *old* query.
+      final pending = c.read(stationSearchProvider);
+      expect(pending.isLoading, isTrue);
+      expect(pending.value!.matches('Preetz'), isFalse);
+      expect(pending.value!.query, 'Kiel');
+    },
+  );
 
   test('a result knows which query it answers', () async {
     final hafas = _ScriptedHafas({
@@ -106,8 +115,9 @@ void main() {
     });
     final c = containerWith(hafas);
     c.read(stationSearchProvider.notifier).search('Preetz');
-    await _until(() =>
-        c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false);
+    await _until(
+      () => c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false,
+    );
 
     final result = c.read(stationSearchProvider).value!;
     expect(result.matches('Preetz'), isTrue);
@@ -115,24 +125,31 @@ void main() {
     expect(result.matches('Preet'), isFalse);
   });
 
-  test('a query too short to search reports itself, not the previous list',
-      () async {
-    final hafas = _ScriptedHafas({'Kiel': (Duration.zero, ['Kiel Hbf'])});
-    final c = containerWith(hafas);
-    final notifier = c.read(stationSearchProvider.notifier);
+  test(
+    'a query too short to search reports itself, not the previous list',
+    () async {
+      final hafas = _ScriptedHafas({
+        'Kiel': (Duration.zero, ['Kiel Hbf']),
+      });
+      final c = containerWith(hafas);
+      final notifier = c.read(stationSearchProvider.notifier);
 
-    notifier.search('Kiel');
-    await _until(() =>
-        c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false);
+      notifier.search('Kiel');
+      await _until(
+        () => c.read(stationSearchProvider).value?.stations.isNotEmpty ?? false,
+      );
 
-    notifier.search('K');
-    final result = c.read(stationSearchProvider).value!;
-    expect(result.query, 'K');
-    expect(result.stations, isEmpty);
-  });
+      notifier.search('K');
+      final result = c.read(stationSearchProvider).value!;
+      expect(result.query, 'K');
+      expect(result.stations, isEmpty);
+    },
+  );
 
   test('stopsOnly is passed through to the backend', () async {
-    final hafas = _ScriptedHafas({'Preetz': (Duration.zero, ['Preetz'])});
+    final hafas = _ScriptedHafas({
+      'Preetz': (Duration.zero, ['Preetz']),
+    });
     final c = containerWith(hafas);
     c.read(stationSearchProvider.notifier)
       ..stopsOnly = true

--- a/flutter-app/test/stopover_plan_provider_test.dart
+++ b/flutter-app/test/stopover_plan_provider_test.dart
@@ -21,14 +21,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// (project_vendo_rate_limit), so the number of requests is a correctness
 /// property: changing the stay must re-search one half, not both.
 
-const _selent =
-    Station(id: '8005292', name: 'Selent', locationId: 'A=1@L=8005292@');
-const _kiel =
-    Station(id: '8000199', name: 'Kiel Hbf', locationId: 'A=1@L=8000199@');
+const _selent = Station(
+  id: '8005292',
+  name: 'Selent',
+  locationId: 'A=1@L=8005292@',
+);
+const _kiel = Station(
+  id: '8000199',
+  name: 'Kiel Hbf',
+  locationId: 'A=1@L=8000199@',
+);
 const _praxis = Station(
-    id: '625109',
-    name: 'Kiel Professor-Peters-Platz',
-    locationId: 'A=1@L=625109@');
+  id: '625109',
+  name: 'Kiel Professor-Peters-Platz',
+  locationId: 'A=1@L=625109@',
+);
 
 final _deadline = DateTime(2026, 7, 27, 9, 48);
 
@@ -42,41 +49,37 @@ Map<String, dynamic> _conn(
   Station to,
   DateTime departure,
   DateTime arrival,
-) =>
-    {
-      'verbindung': {
-        'verbindungsAbschnitte': [
+) => {
+  'verbindung': {
+    'verbindungsAbschnitte': [
+      {
+        'typ': 'FAHRZEUG',
+        'zuglaufId': '${from.id}-${departure.hour}${departure.minute}',
+        'abgangsOrt': {'evaNr': from.id, 'name': from.name},
+        'ankunftsOrt': {'evaNr': to.id, 'name': to.name},
+        'abgangsDatum': _iso(departure),
+        'ankunftsDatum': _iso(arrival),
+        'mitteltext': 'RE 72',
+        'kurztext': 'RE',
+        'zugNummer': '72',
+        'produktGattung': 'REGIONALZUG',
+        'halte': [
           {
-            'typ': 'FAHRZEUG',
-            'zuglaufId': '${from.id}-${departure.hour}${departure.minute}',
-            'abgangsOrt': {'evaNr': from.id, 'name': from.name},
-            'ankunftsOrt': {'evaNr': to.id, 'name': to.name},
+            'ort': {'evaNr': from.id, 'name': from.name},
             'abgangsDatum': _iso(departure),
+          },
+          {
+            'ort': {'evaNr': to.id, 'name': to.name},
             'ankunftsDatum': _iso(arrival),
-            'mitteltext': 'RE 72',
-            'kurztext': 'RE',
-            'zugNummer': '72',
-            'produktGattung': 'REGIONALZUG',
-            'halte': [
-              {
-                'ort': {'evaNr': from.id, 'name': from.name},
-                'abgangsDatum': _iso(departure),
-              },
-              {
-                'ort': {'evaNr': to.id, 'name': to.name},
-                'ankunftsDatum': _iso(arrival),
-              },
-            ],
-          }
+          },
         ],
       },
-    };
+    ],
+  },
+};
 
 String _body(List<Map<String, dynamic>> conns, {String? earlier}) =>
-    json.encode({
-      'verbindungen': conns,
-      if (earlier != null) 'frueherContext': earlier,
-    });
+    json.encode({'verbindungen': conns, 'frueherContext': ?earlier});
 
 /// What one captured search asked for.
 typedef Ask = ({String from, String to, String when, String kind, String? ctx});
@@ -89,22 +92,25 @@ class _Backend {
 
   final asks = <Ask>[];
 
-  VendoService get service => VendoService(client: MockClient((req) async {
-        final body =
-            json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>;
-        final wunsch = (body['reiseHin'] as Map<String, dynamic>)['wunsch']
-            as Map<String, dynamic>;
-        final zeit = wunsch['zeitWunsch'] as Map<String, dynamic>;
-        final ask = (
-          from: wunsch['abgangsLocationId'] as String,
-          to: wunsch['zielLocationId'] as String,
-          when: zeit['reiseDatum'] as String,
-          kind: zeit['zeitPunktArt'] as String,
-          ctx: wunsch['context'] as String?,
-        );
-        asks.add(ask);
-        return http.Response.bytes(utf8.encode(answer(ask)), 200);
-      }));
+  VendoService get service => VendoService(
+    client: MockClient((req) async {
+      final body =
+          json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>;
+      final wunsch =
+          (body['reiseHin'] as Map<String, dynamic>)['wunsch']
+              as Map<String, dynamic>;
+      final zeit = wunsch['zeitWunsch'] as Map<String, dynamic>;
+      final ask = (
+        from: wunsch['abgangsLocationId'] as String,
+        to: wunsch['zielLocationId'] as String,
+        when: zeit['reiseDatum'] as String,
+        kind: zeit['zeitPunktArt'] as String,
+        ctx: wunsch['context'] as String?,
+      );
+      asks.add(ask);
+      return http.Response.bytes(utf8.encode(answer(ask)), 200);
+    }),
+  );
 }
 
 /// Selent → Kiel Hbf, three candidates for the ride to the hub.
@@ -133,15 +139,17 @@ ProviderContainer _container(_Backend backend) {
 /// A backend that answers the hub leg with [_toGoal] and the first leg with
 /// [_toHub], told apart by where the search starts.
 _Backend _twoLegBackend({String? earlier}) => _Backend((ask) {
-      final toGoal = ask.from == _kiel.vendoLocationId;
-      return _body(toGoal ? _toGoal : _toHub, earlier: toGoal ? null : earlier);
-    });
+  final toGoal = ask.from == _kiel.vendoLocationId;
+  return _body(toGoal ? _toGoal : _toHub, earlier: toGoal ? null : earlier);
+});
 
 Future<StopoverPlanState> _plan(
   ProviderContainer container, {
   int stayMinutes = 60,
 }) async {
-  container.read(stopoverPlanProvider.notifier).start(
+  container
+      .read(stopoverPlanProvider.notifier)
+      .start(
         StopoverPlanArgs(
           from: _selent,
           hub: _kiel,
@@ -169,31 +177,36 @@ void main() {
     expect(state.hubDeparture, _at(9, 30));
 
     // Leg 1: both roomy rides, the 5-minute one filtered out and counted.
-    expect([for (final j in state.firstOptions) j.departure],
-        [_at(7, 20), _at(8, 20)]);
+    expect(
+      [for (final j in state.firstOptions) j.departure],
+      [_at(7, 20), _at(8, 20)],
+    );
     expect(state.hiddenFirstCount, 1);
     expect(state.error, isNull);
     expect(state.isLoading, isFalse);
   });
 
-  test('both halves are arrival searches, and the hub one asks for "stay before '
-      'the onward train leaves"', () async {
-    final backend = _twoLegBackend();
-    await _plan(_container(backend), stayMinutes: 60);
+  test(
+    'both halves are arrival searches, and the hub one asks for "stay before '
+    'the onward train leaves"',
+    () async {
+      final backend = _twoLegBackend();
+      await _plan(_container(backend), stayMinutes: 60);
 
-    expect(backend.asks.length, 2);
-    expect(backend.asks.every((a) => a.kind == 'ANKUNFT'), isTrue);
+      expect(backend.asks.length, 2);
+      expect(backend.asks.every((a) => a.kind == 'ANKUNFT'), isTrue);
 
-    // First request: hub → goal, by the appointment.
-    expect(backend.asks[0].from, _kiel.vendoLocationId);
-    expect(backend.asks[0].to, _praxis.vendoLocationId);
-    expect(backend.asks[0].when, startsWith('2026-07-27T09:48'));
+      // First request: hub → goal, by the appointment.
+      expect(backend.asks[0].from, _kiel.vendoLocationId);
+      expect(backend.asks[0].to, _praxis.vendoLocationId);
+      expect(backend.asks[0].when, startsWith('2026-07-27T09:48'));
 
-    // Second: home → hub, by 09:30 minus the wanted hour = 08:30.
-    expect(backend.asks[1].from, _selent.vendoLocationId);
-    expect(backend.asks[1].to, _kiel.vendoLocationId);
-    expect(backend.asks[1].when, startsWith('2026-07-27T08:30'));
-  });
+      // Second: home → hub, by 09:30 minus the wanted hour = 08:30.
+      expect(backend.asks[1].from, _selent.vendoLocationId);
+      expect(backend.asks[1].to, _kiel.vendoLocationId);
+      expect(backend.asks[1].when, startsWith('2026-07-27T08:30'));
+    },
+  );
 
   test('a stay too long for the timetable empties the list and says so, '
       'instead of quietly handing back a tight change', () async {
@@ -208,9 +221,9 @@ void main() {
 
   test('an unreachable appointment is an error, not an empty plan', () async {
     // Only a connection that gets in at 09:57 — after the 09:48 appointment.
-    final backend = _Backend((_) => _body([
-          _conn(_kiel, _praxis, _at(9, 45), _at(9, 57)),
-        ]));
+    final backend = _Backend(
+      (_) => _body([_conn(_kiel, _praxis, _at(9, 45), _at(9, 57))]),
+    );
     final state = await _plan(_container(backend));
 
     expect(state.secondLeg, isNull);
@@ -241,22 +254,26 @@ void main() {
     expect([for (final j in state.firstOptions) j.departure], [_at(7, 20)]);
   });
 
-  test('changing the stay drops the picked ride — it may no longer qualify',
-      () async {
-    final backend = _twoLegBackend();
-    final container = _container(backend);
-    final state = await _plan(container, stayMinutes: 30);
-    final notifier = container.read(stopoverPlanProvider.notifier);
+  test(
+    'changing the stay drops the picked ride — it may no longer qualify',
+    () async {
+      final backend = _twoLegBackend();
+      final container = _container(backend);
+      final state = await _plan(container, stayMinutes: 30);
+      final notifier = container.read(stopoverPlanProvider.notifier);
 
-    notifier.selectFirstLeg(state.firstOptions.last); // the 35-minute one
-    expect(container.read(stopoverPlanProvider).plannedStay,
-        const Duration(minutes: 35));
+      notifier.selectFirstLeg(state.firstOptions.last); // the 35-minute one
+      expect(
+        container.read(stopoverPlanProvider).plannedStay,
+        const Duration(minutes: 35),
+      );
 
-    notifier.setStayMinutes(90);
-    await Future<void>.delayed(Duration.zero);
+      notifier.setStayMinutes(90);
+      await Future<void>.delayed(Duration.zero);
 
-    expect(container.read(stopoverPlanProvider).firstLeg, isNull);
-  });
+      expect(container.read(stopoverPlanProvider).firstLeg, isNull);
+    },
+  );
 
   test('a later appointment re-plans both halves', () async {
     final backend = _twoLegBackend();
@@ -274,34 +291,36 @@ void main() {
     expect(backend.asks[2].from, _kiel.vendoLocationId);
   });
 
-  test('"Früher" walks the ride to the hub further back, deduped and in order',
-      () async {
-    final backend = _Backend((ask) {
-      if (ask.from == _kiel.vendoLocationId) return _body(_toGoal);
-      // The paged window overlaps the first one by the 07:20 ride.
-      if (ask.ctx != null) {
-        return _body([
-          _conn(_selent, _kiel, _at(6, 20), _at(6, 55)),
-          _toHub.first,
-        ]);
-      }
-      return _body(_toHub, earlier: 'frueher-1');
-    });
-    final container = _container(backend);
-    await _plan(container, stayMinutes: 30);
-    expect(container.read(stopoverPlanProvider).firstEarlierRef, 'frueher-1');
+  test(
+    '"Früher" walks the ride to the hub further back, deduped and in order',
+    () async {
+      final backend = _Backend((ask) {
+        if (ask.from == _kiel.vendoLocationId) return _body(_toGoal);
+        // The paged window overlaps the first one by the 07:20 ride.
+        if (ask.ctx != null) {
+          return _body([
+            _conn(_selent, _kiel, _at(6, 20), _at(6, 55)),
+            _toHub.first,
+          ]);
+        }
+        return _body(_toHub, earlier: 'frueher-1');
+      });
+      final container = _container(backend);
+      await _plan(container, stayMinutes: 30);
+      expect(container.read(stopoverPlanProvider).firstEarlierRef, 'frueher-1');
 
-    await container
-        .read(stopoverPlanProvider.notifier)
-        .loadEarlierFirstLegs();
+      await container
+          .read(stopoverPlanProvider.notifier)
+          .loadEarlierFirstLegs();
 
-    expect(backend.asks.last.ctx, 'frueher-1');
-    final state = container.read(stopoverPlanProvider);
-    expect(
-      [for (final j in state.firstOptions) j.departure],
-      [_at(6, 20), _at(7, 20), _at(8, 20)],
-    );
-  });
+      expect(backend.asks.last.ctx, 'frueher-1');
+      final state = container.read(stopoverPlanProvider);
+      expect(
+        [for (final j in state.firstOptions) j.departure],
+        [_at(6, 20), _at(7, 20), _at(8, 20)],
+      );
+    },
+  );
 
   test('a failed search leaves an error, not a half-built plan', () async {
     final container = _container(_Backend((_) => 'not json'));

--- a/flutter-app/test/test/vendo_real_zuglauf_polyline_probe_test.dart
+++ b/flutter-app/test/test/vendo_real_zuglauf_polyline_probe_test.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: avoid_print
+import 'package:besser_bahn/services/vendo_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'probe: fetch polyline using a real zuglaufId',
+    () async {
+      final service = VendoService();
+
+      // 1. Get real journeys from the Vendo API.
+      final result = await service.searchJourneys(
+        fromLocationId: 'A=1@L=8000207@',
+        toLocationId: 'A=1@L=8011160@',
+        dateTime: DateTime.now(),
+      );
+
+      // 2. Find the first real train leg.
+      final trainLeg = result.journeys
+          .expand((journey) => journey.legs)
+          .firstWhere((leg) => !leg.isWalking && leg.tripId != null);
+
+      final zuglaufId = trainLeg.tripId!;
+
+      print('\n========== REAL ZUGLAUF ==========');
+      print('Train: ${trainLeg.line?.fahrtNr}');
+      print('${trainLeg.origin.name} → ${trainLeg.destination.name}');
+      print('zuglaufId: $zuglaufId');
+
+      // 3. Fetch the real train's route geometry.
+      final points = await service.fetchTripPolyline(zuglaufId);
+
+      print('Polyline points: ${points?.length ?? 0}');
+
+      if (points != null && points.isNotEmpty) {
+        print('First point: ${points.first}');
+        print('Last point:  ${points.last}');
+      }
+
+      print('==================================\n');
+
+      expect(points, isNotNull, reason: 'Zuglauf API returned no polyline.');
+
+      expect(
+        points,
+        isNotEmpty,
+        reason: 'Zuglauf API returned an empty polyline.',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 1)),
+  );
+}

--- a/flutter-app/test/vendo_connection_notes_test.dart
+++ b/flutter-app/test/vendo_connection_notes_test.dart
@@ -7,28 +7,27 @@ Map<String, dynamic> _conn({
   Map<String, dynamic>? topNotiz,
   List<Map<String, dynamic>>? echtzeitNotizen,
   List<Map<String, dynamic>>? himNotizen,
-}) =>
-    {
-      'verbindung': {
-        'kontext': 'ctx-1',
-        if (topNotiz != null) 'topNotiz': topNotiz,
-        if (echtzeitNotizen != null) 'echtzeitNotizen': echtzeitNotizen,
-        if (himNotizen != null) 'himNotizen': himNotizen,
-        'verbindungsAbschnitte': [
-          {
-            'typ': 'FAHRZEUG',
-            'mitteltext': 'ICE 947',
-            'kurztext': 'ICE',
-            'produktGattung': 'ICE',
-            'abgangsOrt': {'evaNr': '8000207', 'name': 'Köln Hbf'},
-            'ankunftsOrt': {'evaNr': '8011160', 'name': 'Berlin Hbf'},
-            'abgangsDatum': '2026-07-15T20:44:00+02:00',
-            'ankunftsDatum': '2026-07-16T00:17:00+02:00',
-            'halte': [],
-          }
-        ],
-      }
-    };
+}) => {
+  'verbindung': {
+    'kontext': 'ctx-1',
+    'topNotiz': ?topNotiz,
+    'echtzeitNotizen': ?echtzeitNotizen,
+    'himNotizen': ?himNotizen,
+    'verbindungsAbschnitte': [
+      {
+        'typ': 'FAHRZEUG',
+        'mitteltext': 'ICE 947',
+        'kurztext': 'ICE',
+        'produktGattung': 'ICE',
+        'abgangsOrt': {'evaNr': '8000207', 'name': 'Köln Hbf'},
+        'ankunftsOrt': {'evaNr': '8011160', 'name': 'Berlin Hbf'},
+        'abgangsDatum': '2026-07-15T20:44:00+02:00',
+        'ankunftsDatum': '2026-07-16T00:17:00+02:00',
+        'halte': [],
+      },
+    ],
+  },
+};
 
 void main() {
   group('connection-level notes (#20)', () {
@@ -37,41 +36,53 @@ void main() {
     test('the connection note reaches the journey', () {
       // The live case: the leg carries no notes at all, and this is the only
       // place that says the train stops short of Berlin Hbf.
-      final j = svc.parseConnection(_conn(echtzeitNotizen: [
-        {
-          'prio': 'HOCH',
-          'text': 'Der Zielhalt Berlin Hbf entfällt. '
-              'Ausstieg in Berlin-Spandau möglich.'
-        }
-      ]));
+      final j = svc.parseConnection(
+        _conn(
+          echtzeitNotizen: [
+            {
+              'prio': 'HOCH',
+              'text':
+                  'Der Zielhalt Berlin Hbf entfällt. '
+                  'Ausstieg in Berlin-Spandau möglich.',
+            },
+          ],
+        ),
+      );
 
       expect(j.disruptions, hasLength(1));
       expect(j.disruptions.first, contains('Berlin-Spandau'));
-      expect(j.legs.first.disruptions, isEmpty,
-          reason: 'proves the leg was not the source');
+      expect(
+        j.legs.first.disruptions,
+        isEmpty,
+        reason: 'proves the leg was not the source',
+      );
     });
 
     test('the "textDefault" placeholder never reaches the UI', () {
       // 11 of 15 live connections carry exactly this as topNotiz.
-      final j = svc.parseConnection(_conn(
-        topNotiz: {'prio': 'NORMAL', 'text': 'textDefault'},
-        echtzeitNotizen: [
-          {'prio': 'NORMAL', 'text': 'textDefault'}
-        ],
-      ));
+      final j = svc.parseConnection(
+        _conn(
+          topNotiz: {'prio': 'NORMAL', 'text': 'textDefault'},
+          echtzeitNotizen: [
+            {'prio': 'NORMAL', 'text': 'textDefault'},
+          ],
+        ),
+      );
       expect(j.disruptions, isEmpty);
     });
 
     test('him and realtime notes are merged, deduped', () {
-      final j = svc.parseConnection(_conn(
-        himNotizen: [
-          {'text': 'Bauarbeiten'}
-        ],
-        echtzeitNotizen: [
-          {'text': 'Bauarbeiten'},
-          {'text': 'Verbindung fällt aus'},
-        ],
-      ));
+      final j = svc.parseConnection(
+        _conn(
+          himNotizen: [
+            {'text': 'Bauarbeiten'},
+          ],
+          echtzeitNotizen: [
+            {'text': 'Bauarbeiten'},
+            {'text': 'Verbindung fällt aus'},
+          ],
+        ),
+      );
       expect(j.disruptions, ['Bauarbeiten', 'Verbindung fällt aus']);
     });
 
@@ -87,8 +98,9 @@ void main() {
     /// the run really terminates at Berlin-Spandau 00:04 on platform 5.
     Map<String, dynamic> connEndingEarly() {
       final c = _conn();
-      final leg = (c['verbindung']
-          as Map<String, dynamic>)['verbindungsAbschnitte'] as List;
+      final leg =
+          (c['verbindung'] as Map<String, dynamic>)['verbindungsAbschnitte']
+              as List;
       (leg.first as Map<String, dynamic>)['ersatzZielhaltIndex'] = 4;
       (leg.first as Map<String, dynamic>)['ersatzAnkunftsHalt'] = {
         'ankunftsDatum': '2026-07-16T00:04:00+02:00',
@@ -141,17 +153,17 @@ void main() {
     final svc = VendoService();
 
     /// Live shape: both classes are always present.
-    Map<String, dynamic> connWithLoad(
-        {int? first = 2, int? second = 3}) {
+    Map<String, dynamic> connWithLoad({int? first = 2, int? second = 3}) {
       final c = _conn();
-      final legs = (c['verbindung']
-          as Map<String, dynamic>)['verbindungsAbschnitte'] as List;
+      final legs =
+          (c['verbindung'] as Map<String, dynamic>)['verbindungsAbschnitte']
+              as List;
       (legs.first as Map<String, dynamic>)['auslastungsInfos'] = [
         if (first != null)
           {
             'klasse': 'KLASSE_1',
             'stufe': first,
-            'anzeigeTextKurz': 'Mittlere Auslastung erwartet'
+            'anzeigeTextKurz': 'Mittlere Auslastung erwartet',
           },
         if (second != null) {'klasse': 'KLASSE_2', 'stufe': second},
       ];
@@ -161,8 +173,10 @@ void main() {
     test('a first-class search reads the first-class load', () {
       // This read KLASSE_2 unconditionally, so a first-class rider never saw
       // any occupancy — despite KLASSE_1 being present on every entry probed.
-      final leg =
-          svc.parseConnection(connWithLoad(), firstClass: true).legs.first;
+      final leg = svc
+          .parseConnection(connWithLoad(), firstClass: true)
+          .legs
+          .first;
       expect(leg.occupancy?.level, OccupancyLevel.medium);
     });
 

--- a/flutter-app/test/vendo_real_zuglauf_probe_test.dart
+++ b/flutter-app/test/vendo_real_zuglauf_probe_test.dart
@@ -1,0 +1,54 @@
+// ignore_for_file: avoid_print
+import 'package:besser_bahn/services/vendo_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'probe: extract real zuglauf IDs from Vendo journey search',
+    () async {
+      final service = VendoService();
+
+      final result = await service.searchJourneys(
+        fromLocationId: 'A=1@L=8000207@',
+        toLocationId: 'A=1@L=8011160@',
+        dateTime: DateTime.now(),
+      );
+
+      print('\n========== REAL ZUGLAUF IDS ==========');
+
+      var count = 0;
+
+      for (final journey in result.journeys) {
+        for (final leg in journey.legs) {
+          if (leg.isWalking || leg.tripId == null) {
+            continue;
+          }
+
+          count++;
+
+          print(
+            '[$count] '
+            '${leg.origin.name} → ${leg.destination.name} | '
+            'train=${leg.line?.fahrtNr ?? 'unknown'} | '
+            'tripId=${leg.tripId}',
+          );
+        }
+      }
+
+      print('======================================\n');
+
+      expect(
+        result.journeys,
+        isNotEmpty,
+        reason: 'The real Vendo API returned no journeys.',
+      );
+
+      expect(
+        count,
+        greaterThan(0),
+        reason: 'No non-walking leg with a zuglaufId was found.',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 1)),
+  );
+}

--- a/flutter-app/test/vendo_reroute_test.dart
+++ b/flutter-app/test/vendo_reroute_test.dart
@@ -14,22 +14,24 @@ Map<String, dynamic> _halt(
   bool cancelled = false,
   List<Map<String, String>>? echtzeitNotizen,
   Map<String, String>? serviceNotiz,
-}) =>
-    {
-      'ort': {'evaNr': name, 'name': name},
-      'ankunftsDatum': '2026-07-14T11:38:00+02:00',
-      'abgangsDatum': '2026-07-14T11:40:00+02:00',
-      'gleis': '7',
-      'istZusatzhalt': zusatz,
-      if (cancelled)
-        'ersatzhaltNotiz': {'text': 'Halt entfällt', 'typ': 'GECANCELT'},
-      if (echtzeitNotizen != null) 'echtzeitNotizen': echtzeitNotizen,
-      if (serviceNotiz != null) 'serviceNotiz': serviceNotiz,
-    };
+}) => {
+  'ort': {'evaNr': name, 'name': name},
+  'ankunftsDatum': '2026-07-14T11:38:00+02:00',
+  'abgangsDatum': '2026-07-14T11:40:00+02:00',
+  'gleis': '7',
+  'istZusatzhalt': zusatz,
+  if (cancelled)
+    'ersatzhaltNotiz': {'text': 'Halt entfällt', 'typ': 'GECANCELT'},
+  'echtzeitNotizen': ?echtzeitNotizen,
+  'serviceNotiz': ?serviceNotiz,
+};
 
 Future<dynamic> _trip(Map<String, dynamic> body) {
-  final svc = VendoService(client: MockClient((_) async =>
-      http.Response.bytes(utf8.encode(json.encode(body)), 200)));
+  final svc = VendoService(
+    client: MockClient(
+      (_) async => http.Response.bytes(utf8.encode(json.encode(body)), 200),
+    ),
+  );
   return svc.getTrip('2|#VN#1#ST#1');
 }
 
@@ -39,11 +41,14 @@ void main() {
       final trip = await _trip({
         'mitteltext': 'ICE 844',
         'himNotizen': [
-          {'text': 'Die Strecke ist zwischen Berlin-Spandau und Wolfsburg '
-              'gesperrt.'}
+          {
+            'text':
+                'Die Strecke ist zwischen Berlin-Spandau und Wolfsburg '
+                'gesperrt.',
+          },
         ],
         'echtzeitNotizen': [
-          {'text': 'Verspätung aus vorheriger Fahrt'}
+          {'text': 'Verspätung aus vorheriger Fahrt'},
         ],
         'halte': [_halt('Berlin Hbf'), _halt('Hannover Hbf')],
       });
@@ -62,19 +67,25 @@ void main() {
         'mitteltext': 'ICE 947',
         'halte': [
           _halt('Köln Hbf'),
-          _halt('Berlin-Spandau', echtzeitNotizen: [
-            {'text': 'Neuer Zielhalt'}
-          ]),
-          _halt('Berlin Hbf', cancelled: true, echtzeitNotizen: [
-            {'text': 'Halt entfällt'}
-          ]),
+          _halt(
+            'Berlin-Spandau',
+            echtzeitNotizen: [
+              {'text': 'Neuer Zielhalt'},
+            ],
+          ),
+          _halt(
+            'Berlin Hbf',
+            cancelled: true,
+            echtzeitNotizen: [
+              {'text': 'Halt entfällt'},
+            ],
+          ),
         ],
       });
 
       expect(trip.disruptions, contains('Neuer Zielhalt'));
       expect(trip.disruptions, contains('Halt entfällt'));
     });
-
 
     test('a stop that only lets you off is flagged (#20)', () async {
       // 9 of 450 live stops carry this; without it such a stop looks exactly
@@ -83,14 +94,20 @@ void main() {
         'mitteltext': 'ICE 844',
         'halte': [
           _halt('Berlin Hbf'),
-          _halt('Hannover Hbf', serviceNotiz: {
-            'key': 'text.realtime.stop.entry.disabled',
-            'text': 'Hält nur zum Aussteigen',
-          }),
-          _halt('Köln Hbf', serviceNotiz: {
-            'key': 'text.realtime.stop.exit.disabled',
-            'text': 'Hält nur zum Einsteigen',
-          }),
+          _halt(
+            'Hannover Hbf',
+            serviceNotiz: {
+              'key': 'text.realtime.stop.entry.disabled',
+              'text': 'Hält nur zum Aussteigen',
+            },
+          ),
+          _halt(
+            'Köln Hbf',
+            serviceNotiz: {
+              'key': 'text.realtime.stop.exit.disabled',
+              'text': 'Hält nur zum Einsteigen',
+            },
+          ),
         ],
       });
 
@@ -105,25 +122,27 @@ void main() {
       expect(trip.stopovers[2].noBoarding, isFalse);
     });
 
-    test('attributNotizen stay out of disruptions (amenities, not faults)',
-        () async {
-      final trip = await _trip({
-        'mitteltext': 'ICE 844',
-        'attributNotizen': [
-          {'key': 'WLAN', 'text': 'WLAN verfügbar'}
-        ],
-        'halte': [_halt('Berlin Hbf'), _halt('Hannover Hbf')],
-      });
+    test(
+      'attributNotizen stay out of disruptions (amenities, not faults)',
+      () async {
+        final trip = await _trip({
+          'mitteltext': 'ICE 844',
+          'attributNotizen': [
+            {'key': 'WLAN', 'text': 'WLAN verfügbar'},
+          ],
+          'halte': [_halt('Berlin Hbf'), _halt('Hannover Hbf')],
+        });
 
-      expect(trip.disruptions, isEmpty);
-      expect(trip.attributes, isNotEmpty);
-    });
+        expect(trip.disruptions, isEmpty);
+        expect(trip.attributes, isNotEmpty);
+      },
+    );
 
     test('a note naming an Umleitung marks the run rerouted', () async {
       final trip = await _trip({
         'mitteltext': 'ICE 844',
         'echtzeitNotizen': [
-          {'text': 'Umleitung über Magdeburg'}
+          {'text': 'Umleitung über Magdeburg'},
         ],
         'halte': [_halt('Berlin Hbf'), _halt('Hannover Hbf')],
       });
@@ -164,13 +183,16 @@ void main() {
       final trip = await _trip({
         'mitteltext': 'ICE 844',
         'echtzeitNotizen': [
-          {'text': 'Verspätung aus vorheriger Fahrt'}
+          {'text': 'Verspätung aus vorheriger Fahrt'},
         ],
         'halte': [_halt('Berlin Hbf'), _halt('Hannover Hbf')],
       });
 
-      expect(trip.isRerouted, isFalse,
-          reason: 'delay notes must not trigger the Umleitung banner');
+      expect(
+        trip.isRerouted,
+        isFalse,
+        reason: 'delay notes must not trigger the Umleitung banner',
+      );
       expect(trip.disruptions, isNotEmpty);
     });
 

--- a/flutter-app/test/vendo_transfer_info_test.dart
+++ b/flutter-app/test/vendo_transfer_info_test.dart
@@ -29,37 +29,36 @@ Map<String, dynamic> _leg({
   int? distanz,
   bool weiterfahrtAmGleichenBahnsteig = false,
   String? kurztext,
-}) =>
-    {
-      'typ': typ,
-      if (kurztext != null) 'kurztext': kurztext,
-      'abgangsOrt': {'name': from, 'evaNr': '1'},
-      'ankunftsOrt': {'name': to, 'evaNr': '2'},
-      if (abgang != null) 'abgangsDatum': abgang,
-      if (ankunft != null) 'ankunftsDatum': ankunft,
-      if (dauer != null) 'abschnittsDauer': dauer,
-      if (verfuegbareZeit != null) 'verfuegbareZeit': verfuegbareZeit,
-      if (distanz != null) 'distanz': distanz,
-      'weiterfahrtAmGleichenBahnsteig': weiterfahrtAmGleichenBahnsteig,
-      'halte': const [],
-    };
+}) => {
+  'typ': typ,
+  'kurztext': ?kurztext,
+  'abgangsDatum': ?abgang,
+  'ankunftsDatum': ?ankunft,
+  'abschnittsDauer': ?dauer,
+  'verfuegbareZeit': ?verfuegbareZeit,
+  'distanz': ?distanz,
+  'weiterfahrtAmGleichenBahnsteig': weiterfahrtAmGleichenBahnsteig,
+  'halte': const [],
+};
 
 String _body(List<Map<String, dynamic>> abschnitte) => json.encode({
-      'verbindungen': [
-        {
-          'verbindung': {
-            'kontext': 'ctx',
-            'verbindungsAbschnitte': abschnitte,
-          }
-        }
-      ]
-    });
+  'verbindungen': [
+    {
+      'verbindung': {'kontext': 'ctx', 'verbindungsAbschnitte': abschnitte},
+    },
+  ],
+});
 
 Future<Journey> _parse(List<Map<String, dynamic>> abschnitte) async {
-  final svc = VendoService(client: MockClient((_) async =>
-      http.Response.bytes(utf8.encode(_body(abschnitte)), 200)));
+  final svc = VendoService(
+    client: MockClient(
+      (_) async => http.Response.bytes(utf8.encode(_body(abschnitte)), 200),
+    ),
+  );
   final res = await svc.searchJourneys(
-      fromLocationId: 'A=1@L=8000207@', toLocationId: 'A=1@L=8000261@');
+    fromLocationId: 'A=1@L=8000207@',
+    toLocationId: 'A=1@L=8000261@',
+  );
   return res.journeys.single;
 }
 
@@ -70,28 +69,31 @@ void main() {
     setUp(() async {
       journey = await _parse([
         _leg(
-            typ: 'FAHRZEUG',
-            kurztext: 'ICE',
-            from: 'Köln Hbf',
-            to: 'Köln Messe/Deutz',
-            abgang: '2026-07-18T09:00:00+02:00',
-            ankunft: '2026-07-18T09:06:00+02:00'),
+          typ: 'FAHRZEUG',
+          kurztext: 'ICE',
+          from: 'Köln Hbf',
+          to: 'Köln Messe/Deutz',
+          abgang: '2026-07-18T09:00:00+02:00',
+          ankunft: '2026-07-18T09:06:00+02:00',
+        ),
         _leg(
-            typ: 'FUSSWEG',
-            from: 'Köln Messe/Deutz',
-            to: 'Köln Messe/Deutz Gl.11-12',
-            abgang: '2026-07-18T09:06:00+02:00',
-            ankunft: '2026-07-18T09:18:00+02:00',
-            dauer: 420,
-            verfuegbareZeit: 720,
-            distanz: 59),
+          typ: 'FUSSWEG',
+          from: 'Köln Messe/Deutz',
+          to: 'Köln Messe/Deutz Gl.11-12',
+          abgang: '2026-07-18T09:06:00+02:00',
+          ankunft: '2026-07-18T09:18:00+02:00',
+          dauer: 420,
+          verfuegbareZeit: 720,
+          distanz: 59,
+        ),
         _leg(
-            typ: 'FAHRZEUG',
-            kurztext: 'ICE',
-            from: 'Köln Messe/Deutz Gl.11-12',
-            to: 'München Hbf',
-            abgang: '2026-07-18T09:18:00+02:00',
-            ankunft: '2026-07-18T13:30:00+02:00'),
+          typ: 'FAHRZEUG',
+          kurztext: 'ICE',
+          from: 'Köln Messe/Deutz Gl.11-12',
+          to: 'München Hbf',
+          abgang: '2026-07-18T09:18:00+02:00',
+          ankunft: '2026-07-18T13:30:00+02:00',
+        ),
       ]);
     });
 
@@ -115,43 +117,53 @@ void main() {
     setUp(() async {
       journey = await _parse([
         _leg(
-            typ: 'FAHRZEUG',
-            kurztext: 'ICE',
-            from: 'Köln Hbf',
-            to: 'Mannheim Hbf',
-            abgang: '2026-07-18T09:00:00+02:00',
-            ankunft: '2026-07-18T11:00:00+02:00'),
+          typ: 'FAHRZEUG',
+          kurztext: 'ICE',
+          from: 'Köln Hbf',
+          to: 'Mannheim Hbf',
+          abgang: '2026-07-18T09:00:00+02:00',
+          ankunft: '2026-07-18T11:00:00+02:00',
+        ),
         _leg(
-            typ: 'FUSSWEG',
-            from: 'Mannheim Hbf',
-            to: 'Mannheim Hbf',
-            abgang: '2026-07-18T11:00:00+02:00',
-            ankunft: '2026-07-18T11:12:00+02:00',
-            dauer: 720,
-            weiterfahrtAmGleichenBahnsteig: true),
+          typ: 'FUSSWEG',
+          from: 'Mannheim Hbf',
+          to: 'Mannheim Hbf',
+          abgang: '2026-07-18T11:00:00+02:00',
+          ankunft: '2026-07-18T11:12:00+02:00',
+          dauer: 720,
+          weiterfahrtAmGleichenBahnsteig: true,
+        ),
         _leg(
-            typ: 'FAHRZEUG',
-            kurztext: 'ICE',
-            from: 'Mannheim Hbf',
-            to: 'München Hbf',
-            abgang: '2026-07-18T11:12:00+02:00',
-            ankunft: '2026-07-18T14:00:00+02:00'),
+          typ: 'FAHRZEUG',
+          kurztext: 'ICE',
+          from: 'Mannheim Hbf',
+          to: 'München Hbf',
+          abgang: '2026-07-18T11:12:00+02:00',
+          ankunft: '2026-07-18T14:00:00+02:00',
+        ),
       ]);
     });
 
     test('abschnittsDauer is NOT taken as a walk without verfuegbareZeit', () {
       final walk = journey.legs[1];
       expect(walk.transferAvailable, isNull);
-      expect(walk.walkingDuration, isNull,
-          reason: 'dauer == the whole window here; calling it a 12-min walk '
-              'across one platform would be invented');
+      expect(
+        walk.walkingDuration,
+        isNull,
+        reason:
+            'dauer == the whole window here; calling it a 12-min walk '
+            'across one platform would be invented',
+      );
       expect(walk.transferBufferMinutes, isNull);
     });
 
     test('same-platform flag is read off the walk leg', () {
       expect(journey.legs[1].samePlatformTransfer, isTrue);
-      expect(journey.legs[2].samePlatformTransfer, isFalse,
-          reason: 'DB puts the flag on the FUSSWEG, not on the train');
+      expect(
+        journey.legs[2].samePlatformTransfer,
+        isFalse,
+        reason: 'DB puts the flag on the FUSSWEG, not on the train',
+      );
       // ...and the journey answers for the train you change INTO.
       expect(journey.samePlatformTransferInto(journey.legs[2]), isTrue);
     });
@@ -171,7 +183,10 @@ void main() {
     });
 
     test('still scales a real walk', () {
-      expect(TransferProfile.accessible.effectiveGap(9, samePlatform: false), 5);
+      expect(
+        TransferProfile.accessible.effectiveGap(9, samePlatform: false),
+        5,
+      );
     });
   });
 }

--- a/flutter-app/test/vendo_walking_route_test.dart
+++ b/flutter-app/test/vendo_walking_route_test.dart
@@ -11,8 +11,8 @@ import 'package:http/testing.dart';
 /// the whole reason for asking.
 String _body({int points = 28, int? distance = 683, int? traveltime = 492}) =>
     json.encode({
-      'distance': ?distance,
-      'traveltime': ?traveltime,
+      'distance': distance,
+      'traveltime': traveltime,
       'gpsPositions': [
         for (var i = 0; i < points; i++)
           {'latitude': 50.9435 - i * 0.0001, 'longitude': 6.9595 + i * 0.00001},

--- a/flutter-app/test/vendo_walking_route_test.dart
+++ b/flutter-app/test/vendo_walking_route_test.dart
@@ -11,20 +11,24 @@ import 'package:http/testing.dart';
 /// the whole reason for asking.
 String _body({int points = 28, int? distance = 683, int? traveltime = 492}) =>
     json.encode({
-      if (distance != null) 'distance': distance,
-      if (traveltime != null) 'traveltime': traveltime,
+      'distance': ?distance,
+      'traveltime': ?traveltime,
       'gpsPositions': [
         for (var i = 0; i < points; i++)
           {'latitude': 50.9435 - i * 0.0001, 'longitude': 6.9595 + i * 0.00001},
       ],
     });
 
-Future<WalkingRoute?> _route(http.Response response,
-    {void Function(http.Request)? onRequest}) {
-  final svc = VendoService(client: MockClient((req) async {
-    onRequest?.call(req);
-    return response;
-  }));
+Future<WalkingRoute?> _route(
+  http.Response response, {
+  void Function(http.Request)? onRequest,
+}) {
+  final svc = VendoService(
+    client: MockClient((req) async {
+      onRequest?.call(req);
+      return response;
+    }),
+  );
   return svc.calculateWalkingRoute(
     fromLat: 50.943029,
     fromLon: 6.958730,
@@ -41,10 +45,14 @@ void main() {
       // so asking for WKB would only buy us a decoder.
       late Map<String, dynamic> body;
       late String url;
-      await _route(http.Response(_body(), 200), onRequest: (req) {
-        body = json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>;
-        url = req.url.toString();
-      });
+      await _route(
+        http.Response(_body(), 200),
+        onRequest: (req) {
+          body =
+              json.decode(utf8.decode(req.bodyBytes)) as Map<String, dynamic>;
+          url = req.url.toString();
+        },
+      );
       expect(url, endsWith('/mob/location/calculateroute'));
       expect(body['gpsPositions'], [
         {'latitude': 50.943029, 'longitude': 6.958730},
@@ -67,13 +75,15 @@ void main() {
 
     test('a sub-minute walk is 1 min, never 0', () async {
       final r = await _route(
-          http.Response(_body(distance: 40, traveltime: 35), 200));
+        http.Response(_body(distance: 40, traveltime: 35), 200),
+      );
       expect(r!.summary, '40 m · 1 min');
     });
 
     test('summary uses whatever DB gave', () async {
       final r = await _route(
-          http.Response(_body(distance: null, traveltime: null), 200));
+        http.Response(_body(distance: null, traveltime: null), 200),
+      );
       expect(r!.summary, isNull);
       expect(r.points, hasLength(28));
     });
@@ -96,10 +106,15 @@ void main() {
     test('a failure is null, not an exception — the map still works', () async {
       // The straight line and the blue dot are already on screen; a routing
       // failure must not take the location feature down with it.
-      expect(await _route(http.Response('{"code":"VALIDIERUNG"}', 400)), isNull);
+      expect(
+        await _route(http.Response('{"code":"VALIDIERUNG"}', 400)),
+        isNull,
+      );
       expect(await _route(http.Response('{"code":"FATAL"}', 500)), isNull);
-      expect(await _route(http.Response(json.encode({'distance': 5}), 200)),
-          isNull);
+      expect(
+        await _route(http.Response(json.encode({'distance': 5}), 200)),
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Remove redundant nested Vendo debug logging from connection parsing.
- Keep disruption and realtime-note parsing unchanged.
- Reduce unnecessary log noise during journey parsing.

## Validation

- `flutter analyze` — No issues found
- `flutter test` — All 859 tests passed
- `vendo_rate_limit_test.dart` — All 4 tests passed
- `vendo_walking_route_test.dart` — All walking-route tests passed

## Risk

Low.

This change removes diagnostic logging only. It does not change
journey parsing, API requests, retry behavior, or user-facing data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added journey-result caching to speed up repeated searches and support offline access.
  * Added recent search history, retaining up to 10 searches.
  * Added journey reliability scores with explanations for delays, cancellations, transfers, and disruptions.
  * Added reliability information, offline messaging, cancellation notices, and transfer guidance to journey details.
  * Added journey and search data persistence for faster reloads.

* **Documentation**
  * Replaced the German README with comprehensive English documentation covering features, development, testing, and roadmap.

* **Tests**
  * Expanded coverage for reliability, caching-related flows, stale searches, address handling, and real journey data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->