### PR TITLE
fix(reisen): Auftrag mit mehreren Verbindungen zeigt ganzen Plan

### DIFF
--- a/flutter-app/lib/screens/profile/ticket_detail_screen.dart
+++ b/flutter-app/lib/screens/profile/ticket_detail_screen.dart
@@ -13,6 +13,7 @@ import '../../models/journey.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/service_providers.dart';
 import '../connection_search/connection_detail_screen.dart';
+import '../connection_search/widgets/journey_card.dart';
 import 'widgets/bahncard_view.dart' show openFirstBahnCardControl;
 
 /// Entry point for a booked ticket from the Reisen tab. Loads the ticket,
@@ -87,6 +88,31 @@ class TicketDetailScreen extends ConsumerWidget {
             ),
           );
         }
+        // One order can bundle several legs under a single auftragsnummer — a
+        // round trip books outbound + return, each its own kundenwunschId —
+        // and opening the order used to jump straight into whichever leg was
+        // tapped, with the rest of the plan a tap away and easy to miss. Show
+        // every resolved leg of the order together when there's more than one.
+        final trips =
+            ref.watch(ticketTripsProvider).asData?.value ??
+            const <DbTicketTrip>[];
+        DateTime depOf(DbTicketTrip x) =>
+            x.journey!.plannedDeparture ?? x.journey!.departure ?? DateTime(0);
+        final siblings =
+            trips
+                .where(
+                  (x) =>
+                      x.index.auftragsnummer == auftragsnummer &&
+                      x.journey != null,
+                )
+                .toList()
+              ..sort((a, b) => depOf(a).compareTo(depOf(b)));
+        if (siblings.length > 1) {
+          return _OrderPlanScreen(
+            auftragsnummer: auftragsnummer,
+            trips: siblings,
+          );
+        }
         return ConnectionDetailScreen(
           journey: j,
           ticketRef: (
@@ -95,6 +121,59 @@ class TicketDetailScreen extends ConsumerWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// The full plan for an order that bundles several legs (Hin- und
+/// Rückfahrt) under one auftragsnummer — each leg as the same [JourneyCard]
+/// used everywhere else, in departure order. Tapping one opens its full
+/// Reiseplan (with the Ticket action for that leg), exactly like a
+/// single-leg order always has.
+class _OrderPlanScreen extends StatelessWidget {
+  final String auftragsnummer;
+  final List<DbTicketTrip> trips;
+
+  const _OrderPlanScreen({required this.auftragsnummer, required this.trips});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reiseplan')),
+      body: ListView(
+        padding: const EdgeInsets.only(top: 8, bottom: 24),
+        children: [
+          for (final t in trips) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 12, 16, 4),
+              child: Text(
+                t.ticket?.isReturn == true ? 'Rückfahrt' : 'Hinfahrt',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            JourneyCard(
+              journey: t.journey!,
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => ConnectionDetailScreen(
+                    journey: t.journey!,
+                    ticketRef: (
+                      auftragsnummer: auftragsnummer,
+                      kundenwunschId: t.ticketKey.contains('/')
+                          ? t.ticketKey.split('/').last
+                          : '',
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Problem

Ein Auftrag mit Hin- und Rückfahrt bündelt beide Beine unter derselben
`auftragsnummer`, jedes mit eigener `kundenwunschId`. Beim Öffnen eines
solchen Auftrags aus dem Reisen-Tab sprang die App bisher direkt in das
angetippte Bein (`TicketDetailScreen` → `ConnectionDetailScreen` für genau
eine `kundenwunschId`) — der Rest des Plans war nur über Zurück-Button und
erneutes Antippen der zweiten Kachel erreichbar. Für Nutzer sah das aus wie
"nur die Rückfahrt wird angezeigt".

## Lösung

`TicketDetailScreen` prüft jetzt über das bereits geladene
`ticketTripsProvider`, ob es zur selben `auftragsnummer` weitere aufgelöste
Beine gibt. Bei mehr als einem wird die neue `_OrderPlanScreen` gezeigt:
jedes Bein als dieselbe `JourneyCard`, die auch im Suchergebnis und in der
Reisen-Liste verwendet wird, mit "Hinfahrt"/"Rückfahrt"-Beschriftung
(`DbTicket.isReturn`), sortiert nach Abfahrt. Tippen auf eine Karte öffnet
wie gewohnt den vollen Reiseplan (`ConnectionDetailScreen`) inkl.
Ticket-Aktion für genau dieses Bein.

Für Aufträge mit nur einem Bein ändert sich nichts — das ist weiterhin der
direkte Sprung in den Reiseplan.

## Scope

- Nur `lib/screens/profile/ticket_detail_screen.dart` geändert, +79 Zeilen.
- Keine neuen Widgets erfunden — `JourneyCard` und `ConnectionDetailScreen`
  werden wiederverwendet, gleiches Layout-Pattern wie in der Reisen-Liste
  (Label + Card je Eintrag).
- Keine Breaking Changes an bestehenden Providern/Modellen.

## Test

- `flutter analyze` auf der geänderten Datei: keine Findings.
- Live auf echtem Gerät getestet (DB-Login, Auftrag mit Hin- und
  Rückfahrt geöffnet) — beide Beine werden korrekt zusammen angezeigt,
  Antippen führt in den jeweiligen vollen Reiseplan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Bei Aufträgen mit mehreren Reiseabschnitten wird jetzt eine übersichtliche Reiseplanung angezeigt.
  * Die einzelnen Etappen werden in Abfahrtsreihenfolge dargestellt.
  * Durch Auswahl einer Etappe können die zugehörigen Verbindungsdetails geöffnet werden.
  * Einzelne Fahrten behalten den bisherigen Ablauf bei.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->